### PR TITLE
fix(composition-engine): fix syntax error

### DIFF
--- a/src/composition-engine.js
+++ b/src/composition-engine.js
@@ -101,7 +101,7 @@ export class CompositionEngine {
       }
 
       return instruction.view.loadViewFactory(this.viewEngine).then(viewFactory => {
-        result = viewFactory.create(childContainer, instruction.executionContext);
+        var result = viewFactory.create(instruction.childContainer, instruction.executionContext);
         instruction.viewSlot.swap(result);
         return result;
       });


### PR DESCRIPTION
The current version throws an error when using a `<compose>` element with only the `view` attribute. This change resolves that error.

closes 6