### PR TITLE
Shadowdom inline style

### DIFF
--- a/config.js
+++ b/config.js
@@ -18,6 +18,7 @@ System.config({
     "aurelia-path": "github:aurelia/path@0.5.0",
     "aurelia-task-queue": "github:aurelia/task-queue@0.3.0",
     "core-js": "github:zloirock/core-js@0.8.1",
+    "text": "github:systemjs/plugin-text@0.0.2",
     "github:aurelia/binding@0.5.0": {
       "aurelia-dependency-injection": "github:aurelia/dependency-injection@0.6.0",
       "aurelia-metadata": "github:aurelia/metadata@0.4.0",
@@ -40,4 +41,3 @@ System.config({
     }
   }
 });
-

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
       "aurelia-metadata": "github:aurelia/metadata@^0.4.0",
       "aurelia-path": "github:aurelia/path@^0.5.0",
       "aurelia-task-queue": "github:aurelia/task-queue@^0.3.0",
-      "core-js": "github:zloirock/core-js@^0.8.1"
+      "core-js": "github:zloirock/core-js@^0.8.1",
+      "text": "github:systemjs/plugin-text@^0.0.2"
     }
   },
   "devDependencies": {

--- a/src/util.js
+++ b/src/util.js
@@ -7,3 +7,34 @@ function addHyphenAndLower(char){
 export function hyphenate(name){
   return (name.charAt(0).toLowerCase() + name.slice(1)).replace(capitalMatcher, addHyphenAndLower);
 }
+
+/**
+ * Extracts stylesheet links from template, loads them and inlines its contents
+ * @param {HTMLTemplateElement} template
+ */
+export function swapLinksWithStyleContent(template) {
+  var linkElements = template.content.querySelectorAll('link[rel=stylesheet]'),
+      links = linkElements.map(link => link.href);
+  // remove link elements from template
+  for(let link of linkElements) {
+    template.content.removeChild(link);
+  }
+  // get stylesheets content and inline them on the template
+  return getLinksContent(links).then( styles => {
+    for(let styleContent of styles) {
+      let styleElement = document.createElement('style');
+      styleElement.appendChild(document.createTextNode(styleContent));
+      template.content.appendChild(styleElement);
+    }
+    return template;
+  });
+}
+
+function getLinksContent(links) {
+  var styles = [];
+  for (let link of links) {
+    // TODO: support other types of plugins (stylus, less, sass)
+    styles.push(System.import(`${link}!text`));
+  }
+  return Promise.all(styles);
+}


### PR DESCRIPTION
Fixes https://github.com/aurelia/templating/issues/8 but it's not done yet, it's still a concept because I don't know if it's the aurelia way of doing it and because I haven't been able to test it(some help here?) but the idea is clear.  
I think it's the best option for style encapsulation and the `inlineLinkedCSS` function could be use for the view bundling, inlining the styles when the html is compiled for production.