### PR TITLE
fix(BindableProperty): null changeHandler

### DIFF
--- a/src/bindable-property.js
+++ b/src/bindable-property.js
@@ -62,7 +62,7 @@ export class BindableProperty {
       return;
     }
 
-    if(this.changeHandler !== undefined){
+    if(this.changeHandler !== undefined && this.changeHandler !== null){
       selfSubscriber = (newValue, oldValue) => executionContext[this.changeHandler](newValue, oldValue);
     }
 


### PR DESCRIPTION
hit an error here because changeHandler was null (instead of undefined) when trying some things with the `on-attached.call` custom attribute we were playing around with in the gitter.