### PR TITLE
fix(useshadowdom-noview): Create a shadow root when @noView is used

### DIFF
--- a/src/html-behavior.js
+++ b/src/html-behavior.js
@@ -193,12 +193,14 @@ export class HtmlBehaviorResource {
       if(element){
         element.primaryBehavior = behaviorInstance;
 
-        if(behaviorInstance.view){
-          if(this.usesShadowDOM) {
-            host = element.createShadowRoot();
-          }else{
-            host = element;
+        if(this.usesShadowDOM) {
+          host = element.createShadowRoot();
+        }else{
+          host = element;
+        }
 
+        if(behaviorInstance.view){
+          if(!this.usesShadowDOM) {
             if(instruction.contentFactory){
               var contentView = instruction.contentFactory.create(container, null, contentSelectorFactoryOptions);
 
@@ -206,7 +208,7 @@ export class HtmlBehaviorResource {
                 contentView,
                 behaviorInstance.view.contentSelectors,
                 (contentSelector, group) => contentSelector.add(group)
-                );
+              );
 
               behaviorInstance.contentView = contentView;
             }


### PR DESCRIPTION
This makes sure a shadow root is created when using @useView in combination with @useShadowDOM

fixes: https://github.com/aurelia/templating/issues/66