### PR TITLE
fix(view-slot): add fallback for missing nextElementSibling

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -7,3 +7,10 @@ function addHyphenAndLower(char){
 export function hyphenate(name){
   return (name.charAt(0).toLowerCase() + name.slice(1)).replace(capitalMatcher, addHyphenAndLower);
 }
+
+export function nextElementSibling(element) {
+  if (element.nextElementSibling){ return element.nextElementSibling; }
+  do { element = element.nextSibling }
+  while (element && element.nodeType !== 1);
+  return element;
+}

--- a/src/view-slot.js
+++ b/src/view-slot.js
@@ -1,5 +1,6 @@
 import {ContentSelector} from './content-selector';
 import {Animator} from './animator';
+import {nextElementSibling} from './util';
 
 export class ViewSlot {
   constructor(anchor, anchorIsContainer, executionContext, animator=Animator.instance){
@@ -71,7 +72,7 @@ export class ViewSlot {
     if(this.isAttached){
       view.attached();
       // Animate page itself
-      var element = view.firstChild ? view.firstChild.nextElementSibling : null;
+      var element = view.firstChild ? nextElementSibling(view.firstChild) : null;
       if(view.firstChild &&
         view.firstChild.nodeType === 8 &&
         element &&
@@ -119,7 +120,7 @@ export class ViewSlot {
       return view;
     };
 
-    var element = view.firstChild && view.firstChild.nextElementSibling ? view.firstChild.nextElementSibling : null;
+    var element = view.firstChild ? nextElementSibling(view.firstChild) : null;
     if(view.firstChild &&
       view.firstChild.nodeType === 8 &&
       element &&
@@ -141,7 +142,7 @@ export class ViewSlot {
     var rmPromises = [];
 
     children.forEach(child => {
-      var element = child.firstChild ? child.firstChild.nextElementSibling : null;
+      var element = child.firstChild ? nextElementSibling(child.firstChild) : null;
       if(child.firstChild &&
          child.firstChild.nodeType === 8 &&
          element &&
@@ -199,7 +200,7 @@ export class ViewSlot {
       child = children[i];
       child.attached();
 
-      var element = child.firstChild ? child.firstChild.nextElementSibling : null;
+      var element = child.firstChild ? nextElementSibling(child.firstChild) : null;
       if(child.firstChild &&
         child.firstChild.nodeType === 8 &&
          element &&


### PR DESCRIPTION
When the templates get loaded nextElementSibling is missing in IE. Added helper method to search through nextSiblings to get the next element.

Closes aurelia/animator-css#8