### PR TITLE
feat(customAttribute): enable defaultBindingMode for customAttribute

### DIFF
--- a/src/decorators.js
+++ b/src/decorators.js
@@ -28,10 +28,11 @@ export function customElement(name){
 
 Decorators.configure.parameterizedDecorator('customElement', customElement);
 
-export function customAttribute(name){
+export function customAttribute(name, defaultBindingMode){
   return function(target){
     var resource = Metadata.getOrCreateOwn(Metadata.resource, HtmlBehaviorResource, target);
     resource.attributeName = name;
+    resource.attributeDefaultBindingMode = defaultBindingMode;
   }
 }
 

--- a/src/html-behavior.js
+++ b/src/html-behavior.js
@@ -16,6 +16,7 @@ export class HtmlBehaviorResource {
   constructor(){
     this.elementName = null;
     this.attributeName = null;
+    this.attributeDefaultBindingMode = undefined;
     this.liftsContent = false;
     this.targetShadowDOM = false;
     this.skipContentProcessing = false;
@@ -46,6 +47,7 @@ export class HtmlBehaviorResource {
     var proto = target.prototype,
         properties = this.properties,
         attributeName = this.attributeName,
+        attributeDefaultBindingMode = this.attributeDefaultBindingMode,
         i, ii, current;
 
     this.observerLocator = container.get(ObserverLocator);
@@ -65,7 +67,8 @@ export class HtmlBehaviorResource {
         new BindableProperty({
           name:'value',
           changeHandler:'valueChanged' in proto ? 'valueChanged' : null,
-          attribute:attributeName
+          attribute:attributeName,
+          defaultBindingMode: attributeDefaultBindingMode
         }).registerWith(target, this);
       }
 
@@ -82,7 +85,8 @@ export class HtmlBehaviorResource {
         current = new BindableProperty({
           name:'value',
           changeHandler:'valueChanged' in proto ? 'valueChanged' : null,
-          attribute:attributeName
+          attribute:attributeName,
+          defaultBindingMode: attributeDefaultBindingMode
         });
 
         current.hasOptions = true;

--- a/test/decorators.spec.js
+++ b/test/decorators.spec.js
@@ -1,0 +1,27 @@
+﻿import {Metadata, Decorators} from 'aurelia-metadata';
+import {bindingMode} from 'aurelia-binding';
+import {customAttribute} from '../src/decorators';
+
+describe('decorators', () => {
+    it('should leave resource attributeDefaultBindingMode as undefined when unspecified', () => {
+        var target = {};
+
+        var decorator = customAttribute('test');
+        decorator(target);
+
+        var resource = Metadata.get(Metadata.resource, target);
+        expect(resource.attributeName).toBe('test');
+        expect(resource.attributeDefaultBindingMode).toBeUndefined();
+    });
+
+    it('should set resource attributeDefaultBindingMode when specified', () => {
+        var target = {};
+
+        var decorator = customAttribute('test', bindingMode.twoWay);
+        decorator(target);
+
+        var resource = Metadata.get(Metadata.resource, target);
+        expect(resource.attributeName).toBe('test');
+        expect(resource.attributeDefaultBindingMode).toBe(bindingMode.twoWay);
+    });
+});

--- a/test/html-behavior.spec.js
+++ b/test/html-behavior.spec.js
@@ -1,0 +1,39 @@
+﻿import {Container} from 'aurelia-dependency-injection';
+import {ObserverLocator, bindingMode} from 'aurelia-binding';
+import {TaskQueue} from 'aurelia-task-queue';
+import {HtmlBehaviorResource} from '../src/html-behavior';
+
+describe('html-behavior', () => {
+    var defaultBindingMode = bindingMode.oneWay;
+
+    it('should leave BindableProperty defaultBindingMode undefined after analyze when unspecified', () => {
+        var resource = new HtmlBehaviorResource();
+        resource.attributeName = 'test';
+
+        var container = new Container();
+        container.registerInstance(ObserverLocator, {});
+        container.registerInstance(TaskQueue, {});
+
+        var target = function() {};
+
+        resource.analyze(container, target);
+
+        expect(resource.attributes['test'].defaultBindingMode).toBe(defaultBindingMode);
+    });
+
+    it('should leave set BindableProperty defaultBindingMode after analyze when specified', () => {
+        var resource = new HtmlBehaviorResource();
+        resource.attributeName = 'test';
+        resource.attributeDefaultBindingMode = bindingMode.twoWay;
+
+        var container = new Container();
+        container.registerInstance(ObserverLocator, {});
+        container.registerInstance(TaskQueue, {});
+
+        var target = function() {};
+
+        resource.analyze(container, target);
+
+        expect(resource.attributes['test'].defaultBindingMode).toBe(bindingMode.twoWay);
+    });
+});


### PR DESCRIPTION
Add a second parameter to customAttribute decorator, that allow to
specify the default binding mode on a custom attribute.