### PR TITLE
fix(templating): Use correct import for core-js

### DIFF
--- a/src/bindable-property.js
+++ b/src/bindable-property.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import {hyphenate} from './util';
 import {bindingMode} from 'aurelia-binding';
 

--- a/src/content-selector.js
+++ b/src/content-selector.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 
 if (Element && !Element.prototype.matches) {
     var proto = Element.prototype;

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import {Metadata, Decorators} from 'aurelia-metadata';
 import {BindableProperty} from './bindable-property';
 import {ChildObserver} from './children';

--- a/src/view-engine.js
+++ b/src/view-engine.js
@@ -1,4 +1,4 @@
-import core from 'core-js';
+import * as core from 'core-js';
 import * as LogManager from 'aurelia-logging';
 import {Origin} from 'aurelia-metadata';
 import {Loader,TemplateRegistryEntry} from 'aurelia-loader';


### PR DESCRIPTION
We were previously using `import core from core-js` which generates d.ts that do not match the corejs d.ts. This is now updated to `import * as core 'core-js'`, which resolves TypeScript compilation warnings.

closes aurelia/framework#177