### PR TITLE
d.ts fix - optional property defaultBindingMode

### DIFF
--- a/src/decorators.js
+++ b/src/decorators.js
@@ -35,7 +35,7 @@ export function customElement(name){
 
 Decorators.configure.parameterizedDecorator('customElement', customElement);
 
-export function customAttribute(name, defaultBindingMode){
+export function customAttribute(name, defaultBindingMode?){
   validateBehaviorName(name, 'custom attribute');
   return function(target){
     var resource = Metadata.getOrCreateOwn(Metadata.resource, HtmlBehaviorResource, target);


### PR DESCRIPTION
For d.ts generation i have made defaultBindingMode property in customAttribute decorator as optional.