### PR TITLE
fix(bindable): bindable cannot be undefined

### DIFF
--- a/src/bindable-property.js
+++ b/src/bindable-property.js
@@ -130,7 +130,7 @@ export class BindableProperty {
     } else if(!this.hasOptions){
       observer = observerLookup[this.name];
 
-      if(attributes !== undefined){
+      if (attributes !== null) {
         selfSubscriber = observer.selfSubscriber;
         attribute = attributes[this.attribute];
 


### PR DESCRIPTION
Changes undefined to null to catch errors with nested compose / bindable
scenario