### PR TITLE
feat(dom): check markup for <template> wrapper

### DIFF
--- a/src/dom.js
+++ b/src/dom.js
@@ -16,6 +16,9 @@ export function createTemplateFromMarkup(markup:string):Element{
   parser.innerHTML = markup;
 
   let temp = parser.firstElementChild;
+  if(!temp || temp.nodeName !== 'TEMPLATE'){
+    throw new Error(`Template markup must be wrapped in a <template> element e.g. <template> <!-- markup here --> </template>`);
+  }
 
   if(needsTemplateFixup){
     temp.content = document.createDocumentFragment();

--- a/test/dom.spec.js
+++ b/test/dom.spec.js
@@ -2,6 +2,10 @@
 
 describe('dom', () => {
   describe('createTemplateFromMarkup', () => {
+    it('should create template from valid markup', () => {
+      expect(() => createTemplateFromMarkup('<template>this is valid!</template>')).toBeDefined();
+    });
+
     it('should throw an error when creating a template from text-only markup', () => {
       expect(() => createTemplateFromMarkup('throw an error!')).toThrow();
     });

--- a/test/dom.spec.js
+++ b/test/dom.spec.js
@@ -1,0 +1,13 @@
+﻿import {createTemplateFromMarkup} from '../src/dom';
+
+describe('dom', () => {
+  describe('createTemplateFromMarkup', () => {
+    it('should throw an error when creating a template from text-only markup', () => {
+      expect(() => createTemplateFromMarkup('throw an error!')).toThrow();
+    });
+
+    it('should throw an error when creating a template from markup where <template> is not the root element', () => {
+      expect(() => createTemplateFromMarkup('<div>throw an error!</div>')).toThrow();
+    });
+  });
+});

--- a/test/dom.spec.js
+++ b/test/dom.spec.js
@@ -2,7 +2,7 @@
 
 describe('dom', () => {
   describe('createTemplateFromMarkup', () => {
-    it('should create template from valid markup', () => {
+    it('should create a template from valid markup', () => {
       expect(() => createTemplateFromMarkup('<template>this is valid!</template>')).toBeDefined();
     });
 


### PR DESCRIPTION
Related to #174 

When template markup does not include a template
wrapper, an error is now thrown which specifies how to
resolve the issue.

