### PR TITLE
fix(child, children): Determine actual target by key

### DIFF
--- a/src/child-observation.js
+++ b/src/child-observation.js
@@ -4,7 +4,7 @@ import {HtmlBehaviorResource} from './html-behavior';
 
 function createChildObserverDecorator(selectorOrConfig, all) {
   return function(target, key, descriptor) {
-    let actualTarget = descriptor ? target.constructor : target; //is it on a property or a class?
+    let actualTarget = typeof key === 'string' ? target.constructor : target; //is it on a property or a class?
     let r = metadata.getOrCreateOwn(metadata.resource, HtmlBehaviorResource, actualTarget);
 
     if (typeof selectorOrConfig === 'string') {


### PR DESCRIPTION
TypeScript seems to leave descriptor undefined, so using they key to determine what to actually get the metadata for. Using typeof instead of checking for existence because empty strings ('') are coerced to false, though that SHOULD never happen.