### PR TITLE
feat(ViewSlot): save override context during binding for later eval

### DIFF
--- a/src/view-slot.js
+++ b/src/view-slot.js
@@ -34,6 +34,7 @@ export class ViewSlot {
     this.anchor = anchor;
     this.viewAddMethod = anchorIsContainer ? 'appendNodesTo' : 'insertNodesBefore';
     this.bindingContext = null;
+    this.overrideContext = null;
     this.animator = animator;
     this.children = [];
     this.isBound = false;
@@ -90,6 +91,7 @@ export class ViewSlot {
 
     this.isBound = true;
     this.bindingContext = bindingContext = bindingContext || this.bindingContext;
+    this.overrideContext = overrideContext = overrideContext || this.overrideContext;
 
     children = this.children;
     for (i = 0, ii = children.length; i < ii; ++i) {
@@ -108,6 +110,7 @@ export class ViewSlot {
 
       this.isBound = false;
       this.bindingContext = null;
+      this.overrideContext = null;
 
       for (i = 0, ii = children.length; i < ii; ++i) {
         children[i].unbind();

--- a/test/view-slot.spec.js
+++ b/test/view-slot.spec.js
@@ -60,6 +60,11 @@ describe('view-slot', () => {
         viewSlot.bind(context);
         expect(view.bindingContext).toEqual(context)
       });
+
+      it('applies override context', () => {
+        viewSlot.bind(context, { $index: 0 });
+        expect(viewSlot.overrideContext).toEqual({ $index: 0 });
+      });
     });
 
     describe('.unbind', () => {
@@ -76,6 +81,14 @@ describe('view-slot', () => {
         expect(view.bindingContext).toEqual(context);
         viewSlot.unbind();
         expect(view.bindingContext).toEqual(null);
+      });
+
+      it('removes override context', () => {
+        viewSlot.bind(context, { $index: 0 });
+        expect(viewSlot.overrideContext).toEqual({ $index: 0 });
+        viewSlot.unbind();
+        expect(view.bindingContext).toEqual(null);
+        expect(view.overrideContext).toEqual(null);
       });
     });
   });


### PR DESCRIPTION
When you call `bind` on a ViewSlot, the bindingContext is stored on the slot itself so that optimizations can occur in future binds. This patch simply enforces the same behavior for the override context, so that similar optimizations can be made using that information.


**NOTE:** I ran into the need for this during implementation of a more performant grid implementation I'm working through with @jdanyow. Since each of my "views" in a particular set of rows (for an array view strategy) are, in fact, ViewSlots (each containing a view for the `<td>` cells), it would be incredibly useful for me to have this information in that context. 