### PR TITLE
doc(custom-attribute): switch to automatic private constructor props

### DIFF
--- a/doc/article/en-US/templating-custom-attributes.md
+++ b/doc/article/en-US/templating-custom-attributes.md
@@ -27,6 +27,7 @@ The simplest custom attribute to create is one that changes the behavior of an e
 
 <code-listing heading="red-square.${context.language.fileExtension}">
   <source-code lang="ES 2015/2016">
+
     export class RedSquareCustomAttribute {
       static inject = [Element];
 
@@ -38,12 +39,12 @@ The simplest custom attribute to create is one that changes the behavior of an e
     }
   </source-code>
   <source-code lang="TypeScript">
+
     import {autoinject} from 'aurelia-framework';
 
     @autoinject
     export class RedSquareCustomAttribute {
-      constructor(element: Element){
-          this.element = element;
+      constructor(private element: Element){
           this.element.style.width = this.element.style.height = '100px';
           this.element.style.backgroundColor = 'red';
       }
@@ -53,6 +54,7 @@ The simplest custom attribute to create is one that changes the behavior of an e
 
 <code-listing heading="simple-attribute-usage.html">
   <source-code lang="HTML">
+
     <template>
       <require from="./red-square"></require>
       <div red-square></div>
@@ -68,6 +70,7 @@ Overriding the default naming convention is possible by utilizing the `@customAt
 
 <code-listing heading="red-square.${context.language.fileExtension}">
   <source-code lang="ES 2015/ES 2016/TypeScript">
+
     import {customAttribute} from 'aurelia-framework';
 
     @customAttribute('red-square')
@@ -84,6 +87,7 @@ Aurelia custom attributes support three different types of binding: single value
 
 <code-listing heading="square.${context.language.fileExtension}">
   <source-code lang="ES 2015/2016">
+
     export class SquareCustomAttribute {
       static inject = [Element];
 
@@ -98,14 +102,12 @@ Aurelia custom attributes support three different types of binding: single value
     }
   </source-code>
   <source-code lang="TypeScript">
+
     import {autoinject} from 'aurelia-framework';
 
     @autoinject
     export class SquareCustomAttribute {
-      element: Element;
-
-      constructor(element: Element){
-        this.element = element;
+      constructor(private element: Element){
         this.element.style.width = this.element.style.height = '100px';
       }
 
@@ -118,6 +120,7 @@ Aurelia custom attributes support three different types of binding: single value
 
 <code-listing heading="Simple Attribute with Value Usage">
   <source-code lang="HTML">
+
     <template>
       <require from="./square"></require>
 
@@ -133,6 +136,7 @@ Note that in the above code sample, the color of the square will not be updated,
 
 <code-listing heading="square.${context.language.fileExtension}">
   <source-code lang="ES 2015/2016">
+
     export class SquareCustomAttribute {
       static inject = [Element];
 
@@ -147,14 +151,12 @@ Note that in the above code sample, the color of the square will not be updated,
     }
   </source-code>
   <source-code lang="TypeScript">
+
     import {autoinject} from 'aurelia-framework';
 
     @autoinject
     export class SquareCustomAttribute {
-      element: Element;
-
-      constructor(element: Element){
-        this.element = element;
+      constructor(private element: Element){
         this.element.style.width = this.element.style.height = '100px';
       }
 
@@ -167,6 +169,7 @@ Note that in the above code sample, the color of the square will not be updated,
 
 <code-listing heading="Simple Attribute with Value Usage">
   <source-code lang="HTML">
+
     <template>
       <require from="./square"></require>
 
@@ -187,6 +190,7 @@ Options binding provides a custom attribute the ability to have multiple bindabl
 
 <code-listing heading="square.${context.language.fileExtension}">
   <source-code lang="ES 2015/2016">
+
     import {bindable, inject} from 'aurelia-framework';
 
     @inject(Element)
@@ -208,6 +212,7 @@ Options binding provides a custom attribute the ability to have multiple bindabl
     }
   </source-code>
   <source-code lang="TypeScript">
+
     import {bindable, autoinject} from 'aurelia-framework';
 
     @autoinject
@@ -215,8 +220,7 @@ Options binding provides a custom attribute the ability to have multiple bindabl
       @bindable sideLength: string;
       @bindable color: string;
 
-      constructor(element: Element){
-        this.element = element;
+      constructor(private element: Element){
       }
 
       sideLengthChanged(newValue:string, oldValue:string){
@@ -232,6 +236,7 @@ Options binding provides a custom attribute the ability to have multiple bindabl
 
 <code-listing heading="Single Value Binding Usage">
   <source-code lang="HTML">
+
     <template>
       <require from="./square"></require>
 
@@ -246,6 +251,7 @@ Utilizing dynamic options, a custom attribute may deal with bindable properties 
 
 <code-listing heading="square.${context.language.fileExtension}">
   <source-code lang="ES 2015/2016">
+
     import {dynamicOptions, inject} from 'aurelia-framework';
 
     @dynamicOptions
@@ -261,7 +267,7 @@ Utilizing dynamic options, a custom attribute may deal with bindable properties 
             this.element.style.backgroundColor = newValue;
             break;
           case 'size':
-            this.element.style.width = this.element.style.height = newValue;
+            this.element.style.width = this.element.style.height = `${newValue}px`;
             break;
           default:
             this.element.style[name] = value;
@@ -271,13 +277,13 @@ Utilizing dynamic options, a custom attribute may deal with bindable properties 
     }
   </source-code>
   <source-code lang="TypeScript">
+
     import {dynamicOptions, autoinject} from 'aurelia-framework';
 
     @dynamicOptions
     @autoinject
     export class RedSquareCustomAttribute {
-      constructor(element: Element){
-        this.element = element;
+      constructor(private element: Element){
       }
 
       propertyChanged(name: string, newValue: string, oldValue: string){
@@ -299,6 +305,7 @@ Utilizing dynamic options, a custom attribute may deal with bindable properties 
 
 <code-listing heading="Single Value Binding Usage">
   <source-code lang="HTML">
+
     <template>
       <require from="./square"></require>
 


### PR DESCRIPTION
This switches to a more idiomatic TypeScript syntax for assigning private properties.