### PR TITLE
feat(ViewSlot): allow removal of many views at once to avoid a race condition

### DIFF
--- a/test/view-slot.spec.js
+++ b/test/view-slot.spec.js
@@ -237,6 +237,19 @@ describe('view-slot', () => {
       });
     });
 
+    describe('.removeMany', () => {
+      it('removes many views from children synchronously', () => {
+        viewSlot.add(view);
+        viewSlot.add(secondView);
+        viewSlot.add(thirdView);
+        expect(viewSlot.children.length).toEqual(3);
+        viewSlot.removeMany([view, thirdView]);
+        expect(viewSlot.children.length).toEqual(1);
+        viewSlot.removeMany([secondView]);
+        expect(viewSlot.children.length).toEqual(0);
+      });
+    });
+
     describe('.attached', () => {
       it('sets attached on the slot', () => {
         expect(viewSlot.isAttached).toEqual(false);


### PR DESCRIPTION
One more thing required to work with: https://github.com/aurelia/templating-resources/pull/215.
Removing one-by-one in the for-loop caused some race-conditions when the method was invoked too fast (like in the dbmonster example). The reason was that the indicies were changing as views were being removed. Having a function similar to `removeAll` solves this problem. This is also why the input to the function is not a list of indicies, but the array of `View`'s themselves.