### PR TITLE
feat(module-analyzer): Enable registering ViewEngineHooks by convention.

### DIFF
--- a/dist/amd/aurelia-templating.d.ts
+++ b/dist/amd/aurelia-templating.d.ts
@@ -27,6 +27,7 @@ declare module 'aurelia-templating' {
     createOverrideContext,
     ValueConverterResource,
     BindingBehaviorResource,
+    ViewEngineHooksResource,
     subscriberCollection,
     bindingMode,
     ObserverLocator,

--- a/dist/amd/aurelia-templating.js
+++ b/dist/amd/aurelia-templating.js
@@ -2974,6 +2974,9 @@ define(['exports', 'aurelia-logging', 'aurelia-pal', 'aurelia-metadata', 'aureli
           } else if (conventional = _aureliaBinding.BindingBehaviorResource.convention(key)) {
             resources.push(new ResourceDescription(key, exportedValue, conventional));
             _aureliaMetadata.metadata.define(_aureliaMetadata.metadata.resource, conventional, exportedValue);
+          } else if (conventional = _aureliaBinding.ViewEngineHooksResource.convention(key)) {
+            resources.push(new ResourceDescription(key, exportedValue, conventional));
+            _aureliaMetadata.metadata.define(_aureliaMetadata.metadata.resource, conventional, exportedValue);
           } else if (!fallbackValue) {
             fallbackValue = exportedValue;
             fallbackKey = key;

--- a/dist/aurelia-templating.d.ts
+++ b/dist/aurelia-templating.d.ts
@@ -27,6 +27,7 @@ declare module 'aurelia-templating' {
     createOverrideContext,
     ValueConverterResource,
     BindingBehaviorResource,
+    ViewEngineHooksResource,
     subscriberCollection,
     bindingMode,
     ObserverLocator,

--- a/dist/aurelia-templating.js
+++ b/dist/aurelia-templating.js
@@ -4,7 +4,7 @@ import {Origin,protocol,metadata} from 'aurelia-metadata';
 import {relativeToFile} from 'aurelia-path';
 import {TemplateRegistryEntry,Loader} from 'aurelia-loader';
 import {inject,Container,resolver} from 'aurelia-dependency-injection';
-import {Binding,createOverrideContext,ValueConverterResource,BindingBehaviorResource,subscriberCollection,bindingMode,ObserverLocator,EventManager} from 'aurelia-binding';
+import {Binding,createOverrideContext,ValueConverterResource,BindingBehaviorResource,ViewEngineHooksResource,subscriberCollection,bindingMode,ObserverLocator,EventManager} from 'aurelia-binding';
 import {TaskQueue} from 'aurelia-task-queue';
 
 /**
@@ -3562,6 +3562,9 @@ export class ModuleAnalyzer {
           resources.push(new ResourceDescription(key, exportedValue, conventional));
           metadata.define(metadata.resource, conventional, exportedValue);
         } else if (conventional = BindingBehaviorResource.convention(key)) {
+          resources.push(new ResourceDescription(key, exportedValue, conventional));
+          metadata.define(metadata.resource, conventional, exportedValue);
+        } else if (conventional = ViewEngineHooksResource.convention(key)) {
           resources.push(new ResourceDescription(key, exportedValue, conventional));
           metadata.define(metadata.resource, conventional, exportedValue);
         } else if (!fallbackValue) {

--- a/dist/commonjs/aurelia-templating.d.ts
+++ b/dist/commonjs/aurelia-templating.d.ts
@@ -27,6 +27,7 @@ declare module 'aurelia-templating' {
     createOverrideContext,
     ValueConverterResource,
     BindingBehaviorResource,
+    ViewEngineHooksResource,
     subscriberCollection,
     bindingMode,
     ObserverLocator,

--- a/dist/commonjs/aurelia-templating.js
+++ b/dist/commonjs/aurelia-templating.js
@@ -2951,6 +2951,9 @@ var ModuleAnalyzer = exports.ModuleAnalyzer = function () {
         } else if (conventional = _aureliaBinding.BindingBehaviorResource.convention(key)) {
           resources.push(new ResourceDescription(key, exportedValue, conventional));
           _aureliaMetadata.metadata.define(_aureliaMetadata.metadata.resource, conventional, exportedValue);
+        } else if (conventional = _aureliaBinding.ViewEngineHooksResource.convention(key)) {
+          resources.push(new ResourceDescription(key, exportedValue, conventional));
+          _aureliaMetadata.metadata.define(_aureliaMetadata.metadata.resource, conventional, exportedValue);
         } else if (!fallbackValue) {
           fallbackValue = exportedValue;
           fallbackKey = key;

--- a/dist/es2015/aurelia-templating.d.ts
+++ b/dist/es2015/aurelia-templating.d.ts
@@ -27,6 +27,7 @@ declare module 'aurelia-templating' {
     createOverrideContext,
     ValueConverterResource,
     BindingBehaviorResource,
+    ViewEngineHooksResource,
     subscriberCollection,
     bindingMode,
     ObserverLocator,

--- a/dist/es2015/aurelia-templating.js
+++ b/dist/es2015/aurelia-templating.js
@@ -6,7 +6,7 @@ import { Origin, protocol, metadata } from 'aurelia-metadata';
 import { relativeToFile } from 'aurelia-path';
 import { TemplateRegistryEntry, Loader } from 'aurelia-loader';
 import { inject, Container, resolver } from 'aurelia-dependency-injection';
-import { Binding, createOverrideContext, ValueConverterResource, BindingBehaviorResource, subscriberCollection, bindingMode, ObserverLocator, EventManager } from 'aurelia-binding';
+import { Binding, createOverrideContext, ValueConverterResource, BindingBehaviorResource, ViewEngineHooksResource, subscriberCollection, bindingMode, ObserverLocator, EventManager } from 'aurelia-binding';
 import { TaskQueue } from 'aurelia-task-queue';
 
 export const animationEvent = {
@@ -2727,6 +2727,9 @@ export let ModuleAnalyzer = class ModuleAnalyzer {
           resources.push(new ResourceDescription(key, exportedValue, conventional));
           metadata.define(metadata.resource, conventional, exportedValue);
         } else if (conventional = BindingBehaviorResource.convention(key)) {
+          resources.push(new ResourceDescription(key, exportedValue, conventional));
+          metadata.define(metadata.resource, conventional, exportedValue);
+        } else if (conventional = ViewEngineHooksResource.convention(key)) {
           resources.push(new ResourceDescription(key, exportedValue, conventional));
           metadata.define(metadata.resource, conventional, exportedValue);
         } else if (!fallbackValue) {

--- a/dist/system/aurelia-templating.d.ts
+++ b/dist/system/aurelia-templating.d.ts
@@ -27,6 +27,7 @@ declare module 'aurelia-templating' {
     createOverrideContext,
     ValueConverterResource,
     BindingBehaviorResource,
+    ViewEngineHooksResource,
     subscriberCollection,
     bindingMode,
     ObserverLocator,

--- a/dist/system/aurelia-templating.js
+++ b/dist/system/aurelia-templating.js
@@ -1,7 +1,9 @@
 'use strict';
 
 System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-metadata', 'aurelia-path', 'aurelia-loader', 'aurelia-dependency-injection', 'aurelia-binding', 'aurelia-task-queue'], function (_export, _context) {
-  var LogManager, DOM, PLATFORM, FEATURE, Origin, protocol, metadata, relativeToFile, TemplateRegistryEntry, Loader, inject, Container, resolver, Binding, createOverrideContext, ValueConverterResource, BindingBehaviorResource, subscriberCollection, bindingMode, ObserverLocator, EventManager, TaskQueue, _createClass, _class3, _temp, _dec, _class4, _dec2, _class5, _dec3, _class6, _dec4, _class7, _dec5, _class8, _class9, _temp2, _dec6, _class10, _class11, _temp3, _class13, _dec7, _class15, _dec8, _class16, _dec9, _class18, _dec10, _class19, _dec11, _class20, _typeof, animationEvent, Animator, CompositionTransaction, capitalMatcher, ElementEvents, ResourceLoadContext, ViewCompileInstruction, BehaviorInstruction, TargetInstruction, viewStrategy, RelativeViewStrategy, ConventionalViewStrategy, NoViewStrategy, TemplateRegistryViewStrategy, InlineViewStrategy, ViewLocator, BindingLanguage, noNodes, SlotCustomAttribute, PassThroughSlot, ShadowSlot, ShadowDOM, ViewResources, View, ViewSlot, ProviderResolver, providerResolverInstance, BoundViewFactory, ViewFactory, nextInjectorId, lastAUTargetID, ViewCompiler, ResourceModule, ResourceDescription, ModuleAnalyzer, logger, ProxyViewFactory, ViewEngine, Controller, BehaviorPropertyObserver, BindableProperty, lastProviderId, HtmlBehaviorResource, ChildObserver, noMutations, ChildObserverBinder, CompositionEngine, ElementConfigResource, defaultShadowDOMOptions, TemplatingEngine;
+  "use strict";
+
+  var LogManager, DOM, PLATFORM, FEATURE, Origin, protocol, metadata, relativeToFile, TemplateRegistryEntry, Loader, inject, Container, resolver, Binding, createOverrideContext, ValueConverterResource, BindingBehaviorResource, ViewEngineHooksResource, subscriberCollection, bindingMode, ObserverLocator, EventManager, TaskQueue, _createClass, _class3, _temp, _dec, _class4, _dec2, _class5, _dec3, _class6, _dec4, _class7, _dec5, _class8, _class9, _temp2, _dec6, _class10, _class11, _temp3, _class13, _dec7, _class15, _dec8, _class16, _dec9, _class18, _dec10, _class19, _dec11, _class20, _typeof, animationEvent, Animator, CompositionTransaction, capitalMatcher, ElementEvents, ResourceLoadContext, ViewCompileInstruction, BehaviorInstruction, TargetInstruction, viewStrategy, RelativeViewStrategy, ConventionalViewStrategy, NoViewStrategy, TemplateRegistryViewStrategy, InlineViewStrategy, ViewLocator, BindingLanguage, noNodes, SlotCustomAttribute, PassThroughSlot, ShadowSlot, ShadowDOM, ViewResources, View, ViewSlot, ProviderResolver, providerResolverInstance, BoundViewFactory, ViewFactory, nextInjectorId, lastAUTargetID, ViewCompiler, ResourceModule, ResourceDescription, ModuleAnalyzer, logger, ProxyViewFactory, ViewEngine, Controller, BehaviorPropertyObserver, BindableProperty, lastProviderId, HtmlBehaviorResource, ChildObserver, noMutations, ChildObserverBinder, CompositionEngine, ElementConfigResource, defaultShadowDOMOptions, TemplatingEngine;
 
   function _classCallCheck(instance, Constructor) {
     if (!(instance instanceof Constructor)) {
@@ -509,6 +511,7 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-metadata', 'aurelia-
       createOverrideContext = _aureliaBinding.createOverrideContext;
       ValueConverterResource = _aureliaBinding.ValueConverterResource;
       BindingBehaviorResource = _aureliaBinding.BindingBehaviorResource;
+      ViewEngineHooksResource = _aureliaBinding.ViewEngineHooksResource;
       subscriberCollection = _aureliaBinding.subscriberCollection;
       bindingMode = _aureliaBinding.bindingMode;
       ObserverLocator = _aureliaBinding.ObserverLocator;
@@ -3151,6 +3154,9 @@ System.register(['aurelia-logging', 'aurelia-pal', 'aurelia-metadata', 'aurelia-
                 resources.push(new ResourceDescription(key, exportedValue, conventional));
                 metadata.define(metadata.resource, conventional, exportedValue);
               } else if (conventional = BindingBehaviorResource.convention(key)) {
+                resources.push(new ResourceDescription(key, exportedValue, conventional));
+                metadata.define(metadata.resource, conventional, exportedValue);
+              } else if (conventional = ViewEngineHooksResource.convention(key)) {
                 resources.push(new ResourceDescription(key, exportedValue, conventional));
                 metadata.define(metadata.resource, conventional, exportedValue);
               } else if (!fallbackValue) {

--- a/src/module-analyzer.js
+++ b/src/module-analyzer.js
@@ -3,6 +3,7 @@ import {Container} from 'aurelia-dependency-injection';
 import {TemplateRegistryEntry} from 'aurelia-loader';
 import {ValueConverterResource} from 'aurelia-binding';
 import {BindingBehaviorResource} from 'aurelia-binding';
+import {ViewEngineHooksResource} from 'aurelia-binding';
 import {HtmlBehaviorResource} from './html-behavior';
 import {viewStrategy, TemplateRegistryViewStrategy} from './view-strategy';
 import {ViewResources} from './view-resources';
@@ -272,6 +273,9 @@ export class ModuleAnalyzer {
           resources.push(new ResourceDescription(key, exportedValue, conventional));
           metadata.define(metadata.resource, conventional, exportedValue);
         } else if (conventional = BindingBehaviorResource.convention(key)) {
+          resources.push(new ResourceDescription(key, exportedValue, conventional));
+          metadata.define(metadata.resource, conventional, exportedValue);
+        } else if (conventional = ViewEngineHooksResource.convention(key)) {
           resources.push(new ResourceDescription(key, exportedValue, conventional));
           metadata.define(metadata.resource, conventional, exportedValue);
         } else if (!fallbackValue) {


### PR DESCRIPTION
depends on https://github.com/aurelia/binding/pull/423.