### PR TITLE
feat(ViewSlot animateView): Attach the animation strategy as a method…

### DIFF
--- a/src/view-slot.js
+++ b/src/view-slot.js
@@ -51,7 +51,7 @@ export class ViewSlot {
    *   @param  direction  The animation direction enter|leave
    *   @returns null or a Promise
    */
-  animateView(view:View, direction:String<enter|leave> = 'enter'):Promise<any> {
+  animateView(view:View, direction:String = 'enter'):Promise<any> {
     let animatableElement = getAnimatableElement(view);
     if (animatableElement !== null && direction in this.animator) {
       return this.animator[direction](animatableElement);

--- a/src/view-slot.js
+++ b/src/view-slot.js
@@ -52,7 +52,7 @@ export class ViewSlot {
    *   @returns null or a Promise
    */
   animateView(view:View, direction:String<enter|leave> = 'enter'):Promise<any> {
-    let animatableElement = this._getAnimatableElement(view);
+    let animatableElement = getAnimatableElement(view);
     if (animatableElement !== null && direction in this.animator) {
       return this.animator[direction](animatableElement);
     }

--- a/src/view-slot.js
+++ b/src/view-slot.js
@@ -233,7 +233,7 @@ export class ViewSlot {
         return;
       }
 
-      let animation = this.animateView(view, 'eave');
+      let animation = this.animateView(view, 'leave');
       if (animation !== null) {
         rmPromises.push(animation.then(() => child.removeNodes()));
       } else {

--- a/src/view-slot.js
+++ b/src/view-slot.js
@@ -46,6 +46,20 @@ export class ViewSlot {
   }
 
   /**
+   *   Runs the animator against the first animatable element found within the view's fragment
+   *   @param  view       The view to use when searching for the element
+   *   @param  direction  The animation direction enter|leave
+   *   @returns null or a Promise
+   */
+  animateView(view:View, direction:String<enter|leave> = 'enter'):Promise<any> {
+    let animatableElement = this._getAnimatableElement(view);
+    if (animatableElement !== null && direction in this.animator) {
+      return this.animator[direction](animatableElement);
+    }
+    return animatableElement;
+  }
+
+  /**
   * Takes the child nodes of an existing element that has been converted into a ViewSlot
   * and makes those nodes into a View within the slot.
   */
@@ -136,9 +150,9 @@ export class ViewSlot {
     if (this.isAttached) {
       view.attached();
 
-      let animatableElement = getAnimatableElement(view);
-      if (animatableElement !== null) {
-        return this.animator.enter(animatableElement);
+      let animation = this.animateView(view, 'enter');
+      if (animation !== null) {
+        return animation;
       }
     }
   }
@@ -163,9 +177,9 @@ export class ViewSlot {
     if (this.isAttached) {
       view.attached();
 
-      let animatableElement = getAnimatableElement(view);
-      if (animatableElement !== null) {
-        return this.animator.enter(animatableElement);
+      let animation = this.animateView(view, 'enter');
+      if (animation !== null) {
+        return animation;
       }
     }
   }
@@ -219,9 +233,9 @@ export class ViewSlot {
         return;
       }
 
-      let animatableElement = getAnimatableElement(child);
-      if (animatableElement !== null) {
-        rmPromises.push(this.animator.leave(animatableElement).then(() => child.removeNodes()));
+      let animation = this.animateView(view, 'eave');
+      if (animation !== null) {
+        rmPromises.push(animation.then(() => child.removeNodes()));
       } else {
         child.removeNodes();
       }
@@ -282,9 +296,9 @@ export class ViewSlot {
     };
 
     if (!skipAnimation) {
-      let animatableElement = getAnimatableElement(view);
-      if (animatableElement !== null) {
-        return this.animator.leave(animatableElement).then(() => removeAction());
+      let animation = this.animateView(view, 'leave');
+      if (animation !== null) {
+        return animation.then(() => removeAction());
       }
     }
 
@@ -309,9 +323,9 @@ export class ViewSlot {
         return;
       }
 
-      let animatableElement = getAnimatableElement(child);
-      if (animatableElement !== null) {
-        rmPromises.push(this.animator.leave(animatableElement).then(() => child.removeNodes()));
+      let animation = this.animateView(child, 'leave');
+      if (animation !== null) {
+        rmPromises.push(animation.then(() => child.removeNodes()));
       } else {
         child.removeNodes();
       }
@@ -360,10 +374,7 @@ export class ViewSlot {
       child = children[i];
       child.attached();
 
-      let element = getAnimatableElement(child);
-      if (element) {
-        this.animator.enter(element);
-      }
+      this.animateView(child, 'enter');
     }
   }
 

--- a/src/view-slot.js
+++ b/src/view-slot.js
@@ -233,7 +233,7 @@ export class ViewSlot {
         return;
       }
 
-      let animation = this.animateView(view, 'leave');
+      let animation = this.animateView(child, 'leave');
       if (animation !== null) {
         rmPromises.push(animation.then(() => child.removeNodes()));
       } else {


### PR DESCRIPTION
… on the viewSlot in order to allow reconfigurability

Add ViewSlot.prototype.animateView():Promise
The purpose of this Pull request is to attach the request for animations to the viewSlot class.
Attaching the request for animations will allow someone to override the way a view is animated in and out, by simply returning a promise from the animateView method.