### PR TITLE
feat(module-analyzer): Enable registering ViewEngineHooks by convention

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -40,7 +40,8 @@ gulp.task('build-index', function(){
     'composition-engine.js',
     'element-config.js',
     'decorators.js',
-    'templating-engine.js'
+    'templating-engine.js',
+    'view-engine-hooks-resource.js'
     ].map(function(file){
       return paths.root + file;
   });

--- a/src/module-analyzer.js
+++ b/src/module-analyzer.js
@@ -1,8 +1,7 @@
 import {metadata} from 'aurelia-metadata';
 import {Container} from 'aurelia-dependency-injection';
 import {TemplateRegistryEntry} from 'aurelia-loader';
-import {ValueConverterResource} from 'aurelia-binding';
-import {BindingBehaviorResource} from 'aurelia-binding';
+import { ValueConverterResource, BindingBehaviorResource, ViewEngineHooksResource } from 'aurelia-binding';
 import {HtmlBehaviorResource} from './html-behavior';
 import {viewStrategy, TemplateRegistryViewStrategy} from './view-strategy';
 import {ViewResources} from './view-resources';
@@ -268,12 +267,14 @@ export class ModuleAnalyzer {
           }
 
           metadata.define(metadata.resource, conventional, exportedValue);
-        } else if (conventional = ValueConverterResource.convention(key)) {
+        } else if (conventional = 
+          ValueConverterResource.convention(key)
+          || BindingBehaviorResource.convention(key)
+          || ViewEngineHooksResource.convention(key)) {
+
           resources.push(new ResourceDescription(key, exportedValue, conventional));
           metadata.define(metadata.resource, conventional, exportedValue);
-        } else if (conventional = BindingBehaviorResource.convention(key)) {
-          resources.push(new ResourceDescription(key, exportedValue, conventional));
-          metadata.define(metadata.resource, conventional, exportedValue);
+        
         } else if (!fallbackValue) {
           fallbackValue = exportedValue;
           fallbackKey = key;

--- a/src/module-analyzer.js
+++ b/src/module-analyzer.js
@@ -1,7 +1,8 @@
 import {metadata} from 'aurelia-metadata';
 import {Container} from 'aurelia-dependency-injection';
 import {TemplateRegistryEntry} from 'aurelia-loader';
-import { ValueConverterResource, BindingBehaviorResource, ViewEngineHooksResource } from 'aurelia-binding';
+import {ValueConverterResource, BindingBehaviorResource} from 'aurelia-binding';
+import {ViewEngineHooksResource} from './view-engine-hooks-resource';
 import {HtmlBehaviorResource} from './html-behavior';
 import {viewStrategy, TemplateRegistryViewStrategy} from './view-strategy';
 import {ViewResources} from './view-resources';

--- a/src/view-engine-hooks-resource.js
+++ b/src/view-engine-hooks-resource.js
@@ -1,0 +1,27 @@
+import {metadata} from 'aurelia-metadata';
+
+export class ViewEngineHooksResource {
+  constructor() {}
+
+  initialize(container, target) {
+    this.instance = container.get(target);
+  }
+
+  register(registry, name) {
+    registry.registerViewEngineHooks(this.instance);
+  }
+
+  load(container, target) {}
+  
+  static convention(name) { // eslint-disable-line
+    if (name.endsWith('ViewEngineHooks')) {
+      return new ViewEngineHooksResource();
+    }
+  }
+}
+
+export function viewEngineHooks(target) { // eslint-disable-line
+  return function(target) {
+    metadata.define(metadata.resource, new ViewEngineHooksResource(), target);
+  };
+}


### PR DESCRIPTION
Includes the `ViewEngineHooksResource` class. Replaces https://github.com/aurelia/templating/pull/371.