### PR TITLE
feat(view-compiler): compile empty templates

### DIFF
--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -127,7 +127,7 @@ export class ViewCompiler {
     this._compileNode(content, resources, instructions, source, 'root', !compileInstruction.targetShadowDOM);
 
     let firstChild = content.firstChild;
-    if (firstChild.nodeType === 1) {
+    if (firstChild && firstChild.nodeType === 1) {
       let targetId = firstChild.getAttribute('au-target-id');
       if (targetId) {
         let ins = instructions[targetId];

--- a/test/view-compiler.spec.js
+++ b/test/view-compiler.spec.js
@@ -24,9 +24,11 @@ describe('ViewCompiler', () => {
   describe('compile', () => {
     it('compiles an empty template', () => {
       var template = document.createElement('template'),
-        node = document.createDocumentFragment();
+        node = document.createDocumentFragment(),
+        factory;
       template.appendChild(node);
-      viewCompiler.compile(template, resources, null);
+      factory = viewCompiler.compile(template, resources, null);
+      expect(factory).not.toBe(null);
     });
   });
 

--- a/test/view-compiler.spec.js
+++ b/test/view-compiler.spec.js
@@ -3,17 +3,17 @@ import {ViewCompiler} from '../src/view-compiler';
 import {ViewResources} from '../src/view-resources';
 
 class MockBindingLanguage {
-  inspectAttribute(resources, elementName, attrName, attrValue){
+  inspectAttribute(resources, elementName, attrName, attrValue) {
   }
 
-  createAttributeInstruction(resources, element, info, existingInstruction){
+  createAttributeInstruction(resources, element, info, existingInstruction) {
   }
 
-  inspectTextContent(resources, value){
+  inspectTextContent(resources, value) {
   }
 }
 
-describe('compileNode', () => {
+describe('ViewCompiler', () => {
   var viewCompiler, language, resources;
   beforeAll(() => {
     language = new MockBindingLanguage();
@@ -21,77 +21,100 @@ describe('compileNode', () => {
     resources = new ViewResources(new ViewResources(), 'app.html');
   });
 
-  it('concatenates adjacent text nodes', () => {
-    var instructions = [], parentInjectorId = 'root', targetLightDOM = true,
+  describe('compile', () => {
+    it('compiles an empty template', () => {
+      var template = document.createElement('template'),
+        node = document.createDocumentFragment();
+      template.appendChild(node);
+      viewCompiler.compile(template, resources, null);
+    });
+  });
+
+  describe('compileNode', () => {
+    it('concatenates adjacent text nodes', () => {
+      var instructions = [], parentInjectorId = 'root', targetLightDOM = true,
         node, parentNode;
 
-    parentNode = document.createElement('div');
-    node = document.createTextNode('Hello');
-    parentNode.appendChild(node);
-    parentNode.appendChild(document.createTextNode(' '));
-    parentNode.appendChild(document.createTextNode('World'));
-    parentNode.appendChild(document.createTextNode('!'));
-    spyOn(language, 'inspectTextContent');
+      parentNode = document.createElement('div');
+      node = document.createTextNode('Hello');
+      parentNode.appendChild(node);
+      parentNode.appendChild(document.createTextNode(' '));
+      parentNode.appendChild(document.createTextNode('World'));
+      parentNode.appendChild(document.createTextNode('!'));
+      spyOn(language, 'inspectTextContent');
 
-    node = viewCompiler._compileNode(node, resources, instructions, parentNode, parentInjectorId, targetLightDOM);
-    expect(language.inspectTextContent).toHaveBeenCalledWith(resources, 'Hello World!');
-    expect(node).toBe(null);
-  });
+      node = viewCompiler._compileNode(node, resources, instructions, parentNode, parentInjectorId, targetLightDOM);
+      expect(language.inspectTextContent).toHaveBeenCalledWith(resources, 'Hello World!');
+      expect(node).toBe(null);
+    });
 
-  it('does not concatenate non-adjacent text nodes', () => {
-    var instructions = [], parentInjectorId = 'root', targetLightDOM = true,
+    it('does not concatenate non-adjacent text nodes', () => {
+      var instructions = [], parentInjectorId = 'root', targetLightDOM = true,
         node, parentNode, nextNode;
 
-    parentNode = document.createElement('div');
-    node = document.createTextNode('Hello');
-    parentNode.appendChild(node);
-    parentNode.appendChild(document.createTextNode(' '));
-    nextNode = document.createElement('em');
-    nextNode.textContent = 'World';
-    parentNode.appendChild(nextNode);
-    parentNode.appendChild(document.createTextNode('!'));
-    spyOn(language, 'inspectTextContent');
+      parentNode = document.createElement('div');
+      node = document.createTextNode('Hello');
+      parentNode.appendChild(node);
+      parentNode.appendChild(document.createTextNode(' '));
+      nextNode = document.createElement('em');
+      nextNode.textContent = 'World';
+      parentNode.appendChild(nextNode);
+      parentNode.appendChild(document.createTextNode('!'));
+      spyOn(language, 'inspectTextContent');
 
-    node = viewCompiler._compileNode(node, resources, instructions, parentNode, parentInjectorId, targetLightDOM);
-    expect(language.inspectTextContent).toHaveBeenCalledWith(resources, 'Hello ');
-    expect(node).toBe(nextNode);
-  });
-
-  it('clears class attributes containing interpolation expressions', () => {
-    var instructions = [], parentInjectorId = 'root', targetLightDOM = true,
-        node = document.createElement('div'), parentNode = null;
-    node.setAttribute('class', 'foo ${bar} baz');
-    spyOn(language, 'inspectAttribute').and.returnValue({ attrName: 'class', expression: {attrToRemove:'class'}, command: null });
-    spyOn(language, 'createAttributeInstruction').and.returnValue({ attributes:{ 'class': { discrete:true,attrToRemove:'class' } }, attrName:'class'  });
-    viewCompiler._compileNode(node, resources, instructions, parentNode, parentInjectorId, targetLightDOM);
-    expect(node.className).toBe('au-target');
-  });
-
-  it('does not clear class attributes with no interpolation expressions', () => {
-    var instructions = [], parentInjectorId = 'root', targetLightDOM = true,
-        node = document.createElement('div'), parentNode = null;
-
-    node.setAttribute('class', 'foo bar baz');
-    node.setAttribute('class.bind', 'someProperty');
-
-    spyOn(language, 'inspectAttribute').and.callFake((resources, attrName, attrValue) => {
-      if (attrName === 'class') {
-        return { attrName: 'class', expression: null, command: null }
-      } else {
-        return { attrName: 'class', expression: null, command: 'bind' };
-      }
+      node = viewCompiler._compileNode(node, resources, instructions, parentNode, parentInjectorId, targetLightDOM);
+      expect(language.inspectTextContent).toHaveBeenCalledWith(resources, 'Hello ');
+      expect(node).toBe(nextNode);
     });
 
-    spyOn(language, 'createAttributeInstruction').and.callFake((resources, node, info) => {
-      if(info.command){
-        return { attributes:{ 'class': { discrete:true } }, attrName:'class'  };
-      }else{
-        return null;
-      }
+    it('clears class attributes containing interpolation expressions', () => {
+      var instructions = [], parentInjectorId = 'root', targetLightDOM = true,
+        node = document.createElement('div'), parentNode = null;
+      node.setAttribute('class', 'foo ${bar} baz');
+      spyOn(language, 'inspectAttribute').and.returnValue({
+        attrName: 'class',
+        expression: {attrToRemove: 'class'},
+        command: null
+      });
+      spyOn(language, 'createAttributeInstruction').and.returnValue({
+        attributes: {
+          'class': {
+            discrete: true,
+            attrToRemove: 'class'
+          }
+        }, attrName: 'class'
+      });
+      viewCompiler._compileNode(node, resources, instructions, parentNode, parentInjectorId, targetLightDOM);
+      expect(node.className).toBe('au-target');
     });
 
-    viewCompiler._compileNode(node, resources, instructions, parentNode, parentInjectorId, targetLightDOM);
-    expect(node.className).toBe('foo bar baz au-target');
+    it('does not clear class attributes with no interpolation expressions', () => {
+      var instructions = [], parentInjectorId = 'root', targetLightDOM = true,
+        node = document.createElement('div'), parentNode = null;
+
+      node.setAttribute('class', 'foo bar baz');
+      node.setAttribute('class.bind', 'someProperty');
+
+      spyOn(language, 'inspectAttribute').and.callFake((resources, attrName, attrValue) => {
+        if (attrName === 'class') {
+          return {attrName: 'class', expression: null, command: null}
+        } else {
+          return {attrName: 'class', expression: null, command: 'bind'};
+        }
+      });
+
+      spyOn(language, 'createAttributeInstruction').and.callFake((resources, node, info) => {
+        if (info.command) {
+          return {attributes: {'class': {discrete: true}}, attrName: 'class'};
+        } else {
+          return null;
+        }
+      });
+
+      viewCompiler._compileNode(node, resources, instructions, parentNode, parentInjectorId, targetLightDOM);
+      expect(node.className).toBe('foo bar baz au-target');
+    });
+
   });
 
 });


### PR DESCRIPTION
- Minor refactoring of unit test spec to include a top-level `ViewCompiler` describe function and a new `compile` describe function which includes the validation test for this fix.

Resolves #385