### PR TITLE
feat(view-engine-hooks-resource): Add ViewEngineHooksResource

### DIFF
--- a/build/paths.js
+++ b/build/paths.js
@@ -50,7 +50,8 @@ paths.files = [
   'composition-engine.js',
   'element-config.js',
   'decorators.js',
-  'templating-engine.js'
+  'templating-engine.js',
+  'view-engine-resource-hooks.js'
 ].map(function(file){
   return paths.root + file;
 });

--- a/src/module-analyzer.js
+++ b/src/module-analyzer.js
@@ -1,8 +1,8 @@
 import {metadata} from 'aurelia-metadata';
 import {Container} from 'aurelia-dependency-injection';
 import {TemplateRegistryEntry} from 'aurelia-loader';
-import {ValueConverterResource} from 'aurelia-binding';
-import {BindingBehaviorResource} from 'aurelia-binding';
+import {ValueConverterResource, BindingBehaviorResource} from 'aurelia-binding';
+import {ViewEngineHooksResource} from './view-engine-hooks-resource';
 import {HtmlBehaviorResource} from './html-behavior';
 import {viewStrategy, TemplateRegistryViewStrategy} from './view-strategy';
 import {ViewResources} from './view-resources';
@@ -268,10 +268,10 @@ export class ModuleAnalyzer {
           }
 
           metadata.define(metadata.resource, conventional, exportedValue);
-        } else if (conventional = ValueConverterResource.convention(key)) {
-          resources.push(new ResourceDescription(key, exportedValue, conventional));
-          metadata.define(metadata.resource, conventional, exportedValue);
-        } else if (conventional = BindingBehaviorResource.convention(key)) {
+        } else if (conventional = 
+          ValueConverterResource.convention(key)
+          || BindingBehaviorResource.convention(key)
+          || ViewEngineHooksResource.convention(key)) {
           resources.push(new ResourceDescription(key, exportedValue, conventional));
           metadata.define(metadata.resource, conventional, exportedValue);
         } else if (!fallbackValue) {

--- a/src/view-engine-hooks-resource.js
+++ b/src/view-engine-hooks-resource.js
@@ -1,0 +1,27 @@
+import {metadata} from 'aurelia-metadata';
+
+export class ViewEngineHooksResource {
+  constructor() {}
+
+  initialize(container, target) {
+    this.instance = container.get(target);
+  }
+
+  register(registry, name) {
+    registry.registerViewEngineHooks(this.instance);
+  }
+
+  load(container, target) {}
+  
+  static convention(name) { // eslint-disable-line
+    if (name.endsWith('ViewEngineHooks')) {
+      return new ViewEngineHooksResource();
+    }
+  }
+}
+
+export function viewEngineHooks(target) { // eslint-disable-line
+  return function(target) {
+    metadata.define(metadata.resource, new ViewEngineHooksResource(), target);
+  };
+}


### PR DESCRIPTION
Allows for generating ViewEngineHooks resources via convention or decorator.

Replaces https://github.com/aurelia/templating/pull/381.