### PR TITLE
fix(view-locator): check 'origin.moduleId' instead of 'origin'

### DIFF
--- a/src/view-locator.js
+++ b/src/view-locator.js
@@ -31,7 +31,7 @@ export class ViewLocator {
 
       viewStrategy.assert(value);
 
-      if (origin) {
+      if (origin.moduleId) {
         value.makeRelativeTo(origin.moduleId);
       }
 
@@ -54,12 +54,12 @@ export class ViewLocator {
     let strategy = metadata.get(ViewLocator.viewStrategyMetadataKey, value);
 
     if (!strategy) {
-      if (!origin) {
+      if (!origin.moduleId) {
         throw new Error('Cannot determine default view strategy for object.', value);
       }
 
       strategy = this.createFallbackViewStrategy(origin);
-    } else if (origin) {
+    } else if (origin.moduleId) {
       strategy.moduleId = origin.moduleId;
     }
 


### PR DESCRIPTION
`if (origin)` was always evaluating to true, because when no Origin is found, an [`unknownOrigin` object is returned](https://github.com/aurelia/metadata/blob/7f50c4cc55ef6c6bf00ae3ffe14d0f97a14ce39e/src/origin.js#L4).
Instead, checking for 'origin.moduleId' will revitalize the currently-dead ifs.
This should mean better and earlier error handling for situations like: https://github.com/aurelia/templating/issues/418