### PR TITLE
fix(BehaviorPropertyObserver): publish immediately when TaskQueue already flushing

### DIFF
--- a/src/behavior-property-observer.js
+++ b/src/behavior-property-observer.js
@@ -39,13 +39,17 @@ export class BehaviorPropertyObserver {
     let oldValue = this.currentValue;
 
     if (oldValue !== newValue) {
-      if (this.publishing && this.notqueued) {
-        this.notqueued = false;
-        this.taskQueue.queueMicroTask(this);
-      }
-
       this.oldValue = oldValue;
       this.currentValue = newValue;
+
+      if (this.publishing && this.notqueued) {
+        if (this.taskQueue.flushing) {
+          this.call();
+        } else {
+          this.notqueued = false;
+          this.taskQueue.queueMicroTask(this);
+        }
+      }
     }
   }
 


### PR DESCRIPTION
fixes aurelia/binding#496, aurelia/binding#479, #363

Requires aurelia/task-queue#16