### PR TITLE
fix(viewResources) - argument name mismatch in call to metadata.define()

### DIFF
--- a/src/decorators.js
+++ b/src/decorators.js
@@ -265,6 +265,6 @@ export function elementConfig(target?): any {
 */
 export function viewResources(...resource) { // eslint-disable-line
   return function(target) {
-    metadata.define(ViewEngine.viewModelRequireMetadataKey, resources, target);
+    metadata.define(ViewEngine.viewModelRequireMetadataKey, resource, target);
   };
 }

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -263,8 +263,8 @@ export function elementConfig(target?): any {
 * Same as: <require from="..."></require>
 * @param resource Either: strings with moduleIds, Objects with 'src' and optionally 'as' properties or one of the classes of the module to be included.
 */
-export function viewResources(...resource) { // eslint-disable-line
+export function viewResources(...resources) { // eslint-disable-line
   return function(target) {
-    metadata.define(ViewEngine.viewModelRequireMetadataKey, resource, target);
+    metadata.define(ViewEngine.viewModelRequireMetadataKey, resources, target);
   };
 }


### PR DESCRIPTION
viewResources decorator uses incorrect argument name in call to metadata.define()