### PR TITLE
fix(view-engine): load template resources in order specified in view

### DIFF
--- a/src/view-engine.js
+++ b/src/view-engine.js
@@ -248,11 +248,14 @@ export class ViewEngine {
 
       //cause compile/load of any associated views second
       //as a result all globals have access to all other globals during compilation
-      for (i = 0, ii = allAnalysis.length; i < ii; ++i) {
-        allAnalysis[i] = allAnalysis[i].load(container, loadContext);
-      }
-
-      return Promise.all(allAnalysis).then(() => resources);
+      // using reduce instead of Promise.all to ensure resources are loaded in order
+      // they are included on the page
+      return allAnalysis.reduce((prev, curr) => {
+        return prev.then(() => {
+          return curr.load(container, loadContext);
+        });
+      }, Promise.resolve())
+        .then(() => resources);
     });
   }
 


### PR DESCRIPTION
I'm not sure if this is exactly how we should accomplish this, but this code will force view resources to be loaded sequentially.

This could slow down loading views that have a bunch of resources, but we don't have much choice (other than more intense refactoring) if we want to guarantee resources are loaded sequentially.

Fixes aurelia/bootstrapper#47, aurelia/skeleton-navigation#659
