### PR TITLE
Fix incorrect parameter name in doc comment

### DIFF
--- a/src/decorators.js
+++ b/src/decorators.js
@@ -261,7 +261,7 @@ export function elementConfig(target?): any {
 /**
 * Decorator: Provides the ability to add resources to the related View
 * Same as: <require from="..."></require>
-* @param resource Either: strings with moduleIds, Objects with 'src' and optionally 'as' properties or one of the classes of the module to be included.
+* @param resources Either: strings with moduleIds, Objects with 'src' and optionally 'as' properties or one of the classes of the module to be included.
 */
 export function viewResources(...resources) { // eslint-disable-line
   return function(target) {


### PR DESCRIPTION
The `resources` parameter was renamed in [this commit](https://github.com/aurelia/templating/commit/b4316233ff2b6365ae1796ba6c4e816e6d98d1b3), but the accompanying parameter comment was left unchanged.