### PR TITLE
fix(view-compiler): fallback to node.data when wholeText is not implemented

### DIFF
--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -158,7 +158,7 @@ export class ViewCompiler {
       return this._compileElement(node, resources, instructions, parentNode, parentInjectorId, targetLightDOM);
     case 3: //text node
       //use wholeText to retrieve the textContent of all adjacent text nodes.
-      let expression = resources.getBindingLanguage(this.bindingLanguage).inspectTextContent(resources, node.wholeText);
+      let expression = resources.getBindingLanguage(this.bindingLanguage).inspectTextContent(resources, node.wholeText || node.data);
       if (expression) {
         let marker = DOM.createElement('au-marker');
         let auTargetID = makeIntoInstructionTarget(marker);


### PR DESCRIPTION
`node.wholeText` does not exist in `jsdom`'s DOM implementation (used e.g. for server-side rendering)