### PR TITLE
Inherited bindable properties in custom elements

### DIFF
--- a/dist/amd/aurelia-templating.js
+++ b/dist/amd/aurelia-templating.js
@@ -65,13 +65,13 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
     };
   }();
 
-  var _class, _temp, _dec, _class2, _dec2, _class3, _dec3, _class4, _dec4, _class5, _dec5, _class6, _class7, _temp2, _dec6, _class8, _class9, _temp3, _class11, _dec7, _class13, _dec8, _class14, _class15, _temp4, _dec9, _class16, _dec10, _class17, _dec11, _class18;
-
   var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) {
     return typeof obj;
   } : function (obj) {
     return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj;
   };
+
+  var _class, _temp, _dec, _class2, _dec2, _class3, _dec3, _class4, _dec4, _class5, _dec5, _class6, _class7, _temp2, _dec6, _class8, _class9, _temp3, _class11, _dec7, _class13, _dec8, _class14, _class15, _temp4, _dec9, _class16, _dec10, _class17, _dec11, _class18;
 
   
 
@@ -321,22 +321,14 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
     };
 
     ElementEvents.prototype.subscribeOnce = function subscribeOnce(eventName, handler) {
-      var _this3 = this;
-
       var bubbles = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
 
       if (handler && typeof handler === 'function') {
-        var _ret = function () {
-          var _handler = function _handler(event) {
-            handler(event);
-            _handler.dispose();
-          };
-          return {
-            v: _this3.subscribe(eventName, _handler, bubbles)
-          };
-        }();
-
-        if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
+        var _handler = function _handler(event) {
+          handler(event);
+          _handler.dispose();
+        };
+        return this.subscribe(eventName, _handler, bubbles);
       }
 
       return undefined;
@@ -1763,7 +1755,7 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
     };
 
     ViewSlot.prototype.removeMany = function removeMany(viewsToRemove, returnToCache, skipAnimation) {
-      var _this4 = this;
+      var _this3 = this;
 
       var children = this.children;
       var ii = viewsToRemove.length;
@@ -1776,7 +1768,7 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
           return;
         }
 
-        var animation = _this4.animateView(child, 'leave');
+        var animation = _this3.animateView(child, 'leave');
         if (animation) {
           rmPromises.push(animation.then(function () {
             return child.removeNodes();
@@ -1787,7 +1779,7 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
       });
 
       var removeAction = function removeAction() {
-        if (_this4.isAttached) {
+        if (_this3.isAttached) {
           for (i = 0; i < ii; ++i) {
             viewsToRemove[i].detached();
           }
@@ -1817,16 +1809,16 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
     };
 
     ViewSlot.prototype.removeAt = function removeAt(index, returnToCache, skipAnimation) {
-      var _this5 = this;
+      var _this4 = this;
 
       var view = this.children[index];
 
       var removeAction = function removeAction() {
-        index = _this5.children.indexOf(view);
+        index = _this4.children.indexOf(view);
         view.removeNodes();
-        _this5.children.splice(index, 1);
+        _this4.children.splice(index, 1);
 
-        if (_this5.isAttached) {
+        if (_this4.isAttached) {
           view.detached();
         }
 
@@ -1850,7 +1842,7 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
     };
 
     ViewSlot.prototype.removeAll = function removeAll(returnToCache, skipAnimation) {
-      var _this6 = this;
+      var _this5 = this;
 
       var children = this.children;
       var ii = children.length;
@@ -1863,7 +1855,7 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
           return;
         }
 
-        var animation = _this6.animateView(child, 'leave');
+        var animation = _this5.animateView(child, 'leave');
         if (animation) {
           rmPromises.push(animation.then(function () {
             return child.removeNodes();
@@ -1874,7 +1866,7 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
       });
 
       var removeAction = function removeAction() {
-        if (_this6.isAttached) {
+        if (_this5.isAttached) {
           for (i = 0; i < ii; ++i) {
             children[i].detached();
           }
@@ -1890,7 +1882,7 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
           }
         }
 
-        _this6.children = [];
+        _this5.children = [];
       };
 
       if (rmPromises.length > 0) {
@@ -1937,7 +1929,7 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
     };
 
     ViewSlot.prototype.projectTo = function projectTo(slots) {
-      var _this7 = this;
+      var _this6 = this;
 
       this.projectToSlots = slots;
       this.add = this._projectionAdd;
@@ -1948,7 +1940,7 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
       this.removeMany = this._projectionRemoveMany;
       this.removeAll = this._projectionRemoveAll;
       this.children.forEach(function (view) {
-        return ShadowDOM.distributeView(view, slots, _this7);
+        return ShadowDOM.distributeView(view, slots, _this6);
       });
     };
 
@@ -2012,10 +2004,10 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
     };
 
     ViewSlot.prototype._projectionRemoveMany = function _projectionRemoveMany(viewsToRemove, returnToCache) {
-      var _this8 = this;
+      var _this7 = this;
 
       viewsToRemove.forEach(function (view) {
-        return _this8.remove(view, returnToCache);
+        return _this7.remove(view, returnToCache);
       });
     };
 
@@ -3128,12 +3120,12 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
 
   var ProxyViewFactory = function () {
     function ProxyViewFactory(promise) {
-      var _this9 = this;
+      var _this8 = this;
 
       
 
       promise.then(function (x) {
-        return _this9.viewFactory = x;
+        return _this8.viewFactory = x;
       });
     }
 
@@ -3187,7 +3179,7 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
     };
 
     ViewEngine.prototype.loadViewFactory = function loadViewFactory(urlOrRegistryEntry, compileInstruction, loadContext, target) {
-      var _this10 = this;
+      var _this9 = this;
 
       loadContext = loadContext || new ResourceLoadContext();
 
@@ -3207,14 +3199,14 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
 
         loadContext.addDependency(urlOrRegistryEntry);
 
-        registryEntry.onReady = _this10.loadTemplateResources(registryEntry, compileInstruction, loadContext, target).then(function (resources) {
+        registryEntry.onReady = _this9.loadTemplateResources(registryEntry, compileInstruction, loadContext, target).then(function (resources) {
           registryEntry.resources = resources;
 
           if (registryEntry.template === null) {
             return registryEntry.factory = null;
           }
 
-          var viewFactory = _this10.viewCompiler.compile(registryEntry.template, resources, compileInstruction);
+          var viewFactory = _this9.viewCompiler.compile(registryEntry.template, resources, compileInstruction);
           return registryEntry.factory = viewFactory;
         });
 
@@ -3263,30 +3255,30 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
     };
 
     ViewEngine.prototype.importViewModelResource = function importViewModelResource(moduleImport, moduleMember) {
-      var _this11 = this;
+      var _this10 = this;
 
       return this.loader.loadModule(moduleImport).then(function (viewModelModule) {
         var normalizedId = _aureliaMetadata.Origin.get(viewModelModule).moduleId;
-        var resourceModule = _this11.moduleAnalyzer.analyze(normalizedId, viewModelModule, moduleMember);
+        var resourceModule = _this10.moduleAnalyzer.analyze(normalizedId, viewModelModule, moduleMember);
 
         if (!resourceModule.mainResource) {
           throw new Error('No view model found in module "' + moduleImport + '".');
         }
 
-        resourceModule.initialize(_this11.container);
+        resourceModule.initialize(_this10.container);
 
         return resourceModule.mainResource;
       });
     };
 
     ViewEngine.prototype.importViewResources = function importViewResources(moduleIds, names, resources, compileInstruction, loadContext) {
-      var _this12 = this;
+      var _this11 = this;
 
       loadContext = loadContext || new ResourceLoadContext();
       compileInstruction = compileInstruction || ViewCompileInstruction.normal;
 
       moduleIds = moduleIds.map(function (x) {
-        return _this12._applyLoaderPlugin(x);
+        return _this11._applyLoaderPlugin(x);
       });
 
       return this.loader.loadAllModules(moduleIds).then(function (imports) {
@@ -3296,8 +3288,8 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
         var normalizedId = void 0;
         var current = void 0;
         var associatedModule = void 0;
-        var container = _this12.container;
-        var moduleAnalyzer = _this12.moduleAnalyzer;
+        var container = _this11.container;
+        var moduleAnalyzer = _this11.moduleAnalyzer;
         var allAnalysis = new Array(imports.length);
 
         for (i = 0, ii = imports.length; i < ii; ++i) {
@@ -3584,16 +3576,18 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
   }()) || _class16);
 
 
-  function getObserver(behavior, instance, name) {
+  function getObserver(instance, name) {
     var lookup = instance.__observers__;
 
     if (lookup === undefined) {
-      if (!behavior.isInitialized) {
-        behavior.initialize(_aureliaDependencyInjection.Container.instance || new _aureliaDependencyInjection.Container(), instance.constructor);
+      var ctor = Object.getPrototypeOf(instance).constructor;
+      var _behavior = _aureliaMetadata.metadata.get(_aureliaMetadata.metadata.resource, ctor);
+      if (!_behavior.isInitialized) {
+        _behavior.initialize(_aureliaDependencyInjection.Container.instance || new _aureliaDependencyInjection.Container(), instance.constructor);
       }
 
-      lookup = behavior.observerLocator.getOrCreateObserversLookup(instance);
-      behavior._ensurePropertiesDefined(instance, lookup);
+      lookup = _behavior.observerLocator.getOrCreateObserversLookup(instance);
+      _behavior._ensurePropertiesDefined(instance, lookup);
     }
 
     return lookup[name];
@@ -3625,13 +3619,13 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
 
       if (descriptor) {
         this.descriptor = descriptor;
-        return this._configureDescriptor(behavior, descriptor);
+        return this._configureDescriptor(descriptor);
       }
 
       return undefined;
     };
 
-    BindableProperty.prototype._configureDescriptor = function _configureDescriptor(behavior, descriptor) {
+    BindableProperty.prototype._configureDescriptor = function _configureDescriptor(descriptor) {
       var name = this.name;
 
       descriptor.configurable = true;
@@ -3650,15 +3644,15 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
       }
 
       descriptor.get = function () {
-        return getObserver(behavior, this, name).getValue();
+        return getObserver(this, name).getValue();
       };
 
       descriptor.set = function (value) {
-        getObserver(behavior, this, name).setValue(value);
+        getObserver(this, name).setValue(value);
       };
 
       descriptor.get.getObserver = function (obj) {
-        return getObserver(behavior, obj, name);
+        return getObserver(obj, name);
       };
 
       return descriptor;
@@ -3930,18 +3924,20 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
         for (i = 0, ii = properties.length; i < ii; ++i) {
           properties[i].defineOn(target, this);
         }
+
+        this._copyInheritedProperties(container, target);
       }
     };
 
     HtmlBehaviorResource.prototype.register = function register(registry, name) {
-      var _this13 = this;
+      var _this12 = this;
 
       if (this.attributeName !== null) {
         registry.registerAttribute(name || this.attributeName, this, this.attributeName);
 
         if (Array.isArray(this.aliases)) {
           this.aliases.forEach(function (alias) {
-            registry.registerAttribute(alias, _this13, _this13.attributeName);
+            registry.registerAttribute(alias, _this12, _this12.attributeName);
           });
         }
       }
@@ -3952,7 +3948,7 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
     };
 
     HtmlBehaviorResource.prototype.load = function load(container, target, loadContext, viewStrategy, transientView) {
-      var _this14 = this;
+      var _this13 = this;
 
       var options = void 0;
 
@@ -3965,8 +3961,8 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
         }
 
         return viewStrategy.loadViewFactory(container.get(ViewEngine), options, loadContext, target).then(function (viewFactory) {
-          if (!transientView || !_this14.viewFactory) {
-            _this14.viewFactory = viewFactory;
+          if (!transientView || !_this13.viewFactory) {
+            _this13.viewFactory = viewFactory;
           }
 
           return viewFactory;
@@ -4158,6 +4154,43 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
       }
     };
 
+    HtmlBehaviorResource.prototype._copyInheritedProperties = function _copyInheritedProperties(container, target) {
+      var _this14 = this;
+
+      var behavior = void 0,
+          derived = target;
+      while (true) {
+        var proto = Object.getPrototypeOf(target.prototype);
+        target = proto && proto.constructor;
+        if (!target) {
+          return;
+        }
+        behavior = _aureliaMetadata.metadata.getOwn(_aureliaMetadata.metadata.resource, target);
+        if (behavior) {
+          break;
+        }
+      }
+      behavior.initialize(container, target);
+
+      var _loop = function _loop(_i8, _ii8) {
+        var prop = behavior.properties[_i8];
+
+        if (_this14.properties.some(function (p) {
+          return p.name === prop.name;
+        })) {
+          return 'continue';
+        }
+
+        new BindableProperty(prop).registerWith(derived, _this14);
+      };
+
+      for (var _i8 = 0, _ii8 = behavior.properties.length; _i8 < _ii8; ++_i8) {
+        var _ret = _loop(_i8, _ii8);
+
+        if (_ret === 'continue') continue;
+      }
+    };
+
     return HtmlBehaviorResource;
   }();
 
@@ -4226,8 +4259,8 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
     var bindersLength = binders.length;
     var groupedMutations = new Map();
 
-    for (var _i8 = 0, _ii8 = mutations.length; _i8 < _ii8; ++_i8) {
-      var record = mutations[_i8];
+    for (var _i9 = 0, _ii9 = mutations.length; _i9 < _ii9; ++_i9) {
+      var record = mutations[_i9];
       var added = record.addedNodes;
       var removed = record.removedNodes;
 
@@ -4295,8 +4328,8 @@ define(['exports', 'aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aureli
         if (assignedSlot && assignedSlot.projectFromAnchors) {
           var anchors = assignedSlot.projectFromAnchors;
 
-          for (var _i9 = 0, _ii9 = anchors.length; _i9 < _ii9; ++_i9) {
-            if (anchors[_i9].auOwnerView === contentView) {
+          for (var _i10 = 0, _ii10 = anchors.length; _i10 < _ii10; ++_i10) {
+            if (anchors[_i10].auOwnerView === contentView) {
               return true;
             }
           }

--- a/dist/aurelia-templating.js
+++ b/dist/aurelia-templating.js
@@ -4457,10 +4457,18 @@ export class BehaviorPropertyObserver {
   }
 }
 
-function getObserver(behavior, instance, name) {
+function getObserver(instance, name) {
   let lookup = instance.__observers__;
 
   if (lookup === undefined) {
+    // We need to lookup the actual behavior for this instance, 
+    // as it might be a derived class (and behavior) rather than 
+    // the class (and behavior) that declared the property calling getObserver().
+    // This means we can't capture the behavior in property get/set/getObserver and pass it here. 
+    // Note that it's probably for the best, as passing the behavior is an overhead 
+    // that is only useful in the very first call of the first property of the instance.
+    let ctor = Object.getPrototypeOf(instance).constructor; // Playing safe here, user could have written to instance.constructor.
+    let behavior = metadata.get(metadata.resource, ctor);
     if (!behavior.isInitialized) {
       behavior.initialize(Container.instance || new Container(), instance.constructor);
     }
@@ -4509,13 +4517,13 @@ export class BindableProperty {
 
     if (descriptor) {
       this.descriptor = descriptor;
-      return this._configureDescriptor(behavior, descriptor);
+      return this._configureDescriptor(descriptor);
     }
 
     return undefined;
   }
 
-  _configureDescriptor(behavior: HtmlBehaviorResource, descriptor: Object): Object {
+  _configureDescriptor(descriptor: Object): Object {
     let name = this.name;
 
     descriptor.configurable = true;
@@ -4534,15 +4542,15 @@ export class BindableProperty {
     }
 
     descriptor.get = function() {
-      return getObserver(behavior, this, name).getValue();
+      return getObserver(this, name).getValue();
     };
 
     descriptor.set = function(value) {
-      getObserver(behavior, this, name).setValue(value);
+      getObserver(this, name).setValue(value);
     };
 
     descriptor.get.getObserver = function(obj) {
-      return getObserver(behavior, obj, name);
+      return getObserver(obj, name);
     };
 
     return descriptor;
@@ -4837,6 +4845,10 @@ export class HtmlBehaviorResource {
       for (i = 0, ii = properties.length; i < ii; ++i) {
         properties[i].defineOn(target, this);
       }
+      // Because how inherited properties would interact with the default 'value' property 
+      // in a custom attribute is not well defined yet, we only inherit properties on 
+      // custom elements, where it's not a problem.
+      this._copyInheritedProperties(container, target);
     }
   }
 
@@ -5099,6 +5111,37 @@ export class HtmlBehaviorResource {
         lookup[observer.propertyName] = observer;
       }
     }
+  }
+
+  _copyInheritedProperties(container: Container, target: Function) {
+    // This methods enables inherited @bindable properties.    
+    // We look for the first base class with metadata, make sure it's initialized 
+    // and copy its properties. 
+    // We don't need to walk further than the first parent with metadata because
+    // it had also inherited properties during its own initialization.
+    let behavior, derived = target;
+    while (true) {
+      let proto = Object.getPrototypeOf(target.prototype);
+      target = proto && proto.constructor;
+      if (!target) {
+        return;
+      }
+      behavior = metadata.getOwn(metadata.resource, target);
+      if (behavior) {
+        break;
+      }
+    }
+    behavior.initialize(container, target);    
+    for (let i = 0, ii = behavior.properties.length; i < ii; ++i) {
+      let prop = behavior.properties[i];
+      // Check that the property metadata was not overriden or re-defined in this class
+      if (this.properties.some(p => p.name === prop.name)) {
+        continue;
+      }
+      // We don't need to call .defineOn() for those properties because it was done
+      // on the parent prototype during initialization.
+      new BindableProperty(prop).registerWith(derived, this);
+    }    
   }
 }
 

--- a/dist/commonjs/aurelia-templating.js
+++ b/dist/commonjs/aurelia-templating.js
@@ -7,9 +7,9 @@ exports.TemplatingEngine = exports.ElementConfigResource = exports.CompositionEn
 
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _class, _temp, _dec, _class2, _dec2, _class3, _dec3, _class4, _dec4, _class5, _dec5, _class6, _class7, _temp2, _dec6, _class8, _class9, _temp3, _class11, _dec7, _class13, _dec8, _class14, _class15, _temp4, _dec9, _class16, _dec10, _class17, _dec11, _class18;
-
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var _class, _temp, _dec, _class2, _dec2, _class3, _dec3, _class4, _dec4, _class5, _dec5, _class6, _class7, _temp2, _dec6, _class8, _class9, _temp3, _class11, _dec7, _class13, _dec8, _class14, _class15, _temp4, _dec9, _class16, _dec10, _class17, _dec11, _class18;
 
 exports._hyphenate = _hyphenate;
 exports._isAllWhitespace = _isAllWhitespace;
@@ -302,22 +302,14 @@ var ElementEvents = exports.ElementEvents = function () {
   };
 
   ElementEvents.prototype.subscribeOnce = function subscribeOnce(eventName, handler) {
-    var _this3 = this;
-
     var bubbles = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
 
     if (handler && typeof handler === 'function') {
-      var _ret = function () {
-        var _handler = function _handler(event) {
-          handler(event);
-          _handler.dispose();
-        };
-        return {
-          v: _this3.subscribe(eventName, _handler, bubbles)
-        };
-      }();
-
-      if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
+      var _handler = function _handler(event) {
+        handler(event);
+        _handler.dispose();
+      };
+      return this.subscribe(eventName, _handler, bubbles);
     }
 
     return undefined;
@@ -1744,7 +1736,7 @@ var ViewSlot = exports.ViewSlot = function () {
   };
 
   ViewSlot.prototype.removeMany = function removeMany(viewsToRemove, returnToCache, skipAnimation) {
-    var _this4 = this;
+    var _this3 = this;
 
     var children = this.children;
     var ii = viewsToRemove.length;
@@ -1757,7 +1749,7 @@ var ViewSlot = exports.ViewSlot = function () {
         return;
       }
 
-      var animation = _this4.animateView(child, 'leave');
+      var animation = _this3.animateView(child, 'leave');
       if (animation) {
         rmPromises.push(animation.then(function () {
           return child.removeNodes();
@@ -1768,7 +1760,7 @@ var ViewSlot = exports.ViewSlot = function () {
     });
 
     var removeAction = function removeAction() {
-      if (_this4.isAttached) {
+      if (_this3.isAttached) {
         for (i = 0; i < ii; ++i) {
           viewsToRemove[i].detached();
         }
@@ -1798,16 +1790,16 @@ var ViewSlot = exports.ViewSlot = function () {
   };
 
   ViewSlot.prototype.removeAt = function removeAt(index, returnToCache, skipAnimation) {
-    var _this5 = this;
+    var _this4 = this;
 
     var view = this.children[index];
 
     var removeAction = function removeAction() {
-      index = _this5.children.indexOf(view);
+      index = _this4.children.indexOf(view);
       view.removeNodes();
-      _this5.children.splice(index, 1);
+      _this4.children.splice(index, 1);
 
-      if (_this5.isAttached) {
+      if (_this4.isAttached) {
         view.detached();
       }
 
@@ -1831,7 +1823,7 @@ var ViewSlot = exports.ViewSlot = function () {
   };
 
   ViewSlot.prototype.removeAll = function removeAll(returnToCache, skipAnimation) {
-    var _this6 = this;
+    var _this5 = this;
 
     var children = this.children;
     var ii = children.length;
@@ -1844,7 +1836,7 @@ var ViewSlot = exports.ViewSlot = function () {
         return;
       }
 
-      var animation = _this6.animateView(child, 'leave');
+      var animation = _this5.animateView(child, 'leave');
       if (animation) {
         rmPromises.push(animation.then(function () {
           return child.removeNodes();
@@ -1855,7 +1847,7 @@ var ViewSlot = exports.ViewSlot = function () {
     });
 
     var removeAction = function removeAction() {
-      if (_this6.isAttached) {
+      if (_this5.isAttached) {
         for (i = 0; i < ii; ++i) {
           children[i].detached();
         }
@@ -1871,7 +1863,7 @@ var ViewSlot = exports.ViewSlot = function () {
         }
       }
 
-      _this6.children = [];
+      _this5.children = [];
     };
 
     if (rmPromises.length > 0) {
@@ -1918,7 +1910,7 @@ var ViewSlot = exports.ViewSlot = function () {
   };
 
   ViewSlot.prototype.projectTo = function projectTo(slots) {
-    var _this7 = this;
+    var _this6 = this;
 
     this.projectToSlots = slots;
     this.add = this._projectionAdd;
@@ -1929,7 +1921,7 @@ var ViewSlot = exports.ViewSlot = function () {
     this.removeMany = this._projectionRemoveMany;
     this.removeAll = this._projectionRemoveAll;
     this.children.forEach(function (view) {
-      return ShadowDOM.distributeView(view, slots, _this7);
+      return ShadowDOM.distributeView(view, slots, _this6);
     });
   };
 
@@ -1993,10 +1985,10 @@ var ViewSlot = exports.ViewSlot = function () {
   };
 
   ViewSlot.prototype._projectionRemoveMany = function _projectionRemoveMany(viewsToRemove, returnToCache) {
-    var _this8 = this;
+    var _this7 = this;
 
     viewsToRemove.forEach(function (view) {
-      return _this8.remove(view, returnToCache);
+      return _this7.remove(view, returnToCache);
     });
   };
 
@@ -3109,12 +3101,12 @@ function ensureRegistryEntry(loader, urlOrRegistryEntry) {
 
 var ProxyViewFactory = function () {
   function ProxyViewFactory(promise) {
-    var _this9 = this;
+    var _this8 = this;
 
     
 
     promise.then(function (x) {
-      return _this9.viewFactory = x;
+      return _this8.viewFactory = x;
     });
   }
 
@@ -3168,7 +3160,7 @@ var ViewEngine = exports.ViewEngine = (_dec8 = (0, _aureliaDependencyInjection.i
   };
 
   ViewEngine.prototype.loadViewFactory = function loadViewFactory(urlOrRegistryEntry, compileInstruction, loadContext, target) {
-    var _this10 = this;
+    var _this9 = this;
 
     loadContext = loadContext || new ResourceLoadContext();
 
@@ -3188,14 +3180,14 @@ var ViewEngine = exports.ViewEngine = (_dec8 = (0, _aureliaDependencyInjection.i
 
       loadContext.addDependency(urlOrRegistryEntry);
 
-      registryEntry.onReady = _this10.loadTemplateResources(registryEntry, compileInstruction, loadContext, target).then(function (resources) {
+      registryEntry.onReady = _this9.loadTemplateResources(registryEntry, compileInstruction, loadContext, target).then(function (resources) {
         registryEntry.resources = resources;
 
         if (registryEntry.template === null) {
           return registryEntry.factory = null;
         }
 
-        var viewFactory = _this10.viewCompiler.compile(registryEntry.template, resources, compileInstruction);
+        var viewFactory = _this9.viewCompiler.compile(registryEntry.template, resources, compileInstruction);
         return registryEntry.factory = viewFactory;
       });
 
@@ -3244,30 +3236,30 @@ var ViewEngine = exports.ViewEngine = (_dec8 = (0, _aureliaDependencyInjection.i
   };
 
   ViewEngine.prototype.importViewModelResource = function importViewModelResource(moduleImport, moduleMember) {
-    var _this11 = this;
+    var _this10 = this;
 
     return this.loader.loadModule(moduleImport).then(function (viewModelModule) {
       var normalizedId = _aureliaMetadata.Origin.get(viewModelModule).moduleId;
-      var resourceModule = _this11.moduleAnalyzer.analyze(normalizedId, viewModelModule, moduleMember);
+      var resourceModule = _this10.moduleAnalyzer.analyze(normalizedId, viewModelModule, moduleMember);
 
       if (!resourceModule.mainResource) {
         throw new Error('No view model found in module "' + moduleImport + '".');
       }
 
-      resourceModule.initialize(_this11.container);
+      resourceModule.initialize(_this10.container);
 
       return resourceModule.mainResource;
     });
   };
 
   ViewEngine.prototype.importViewResources = function importViewResources(moduleIds, names, resources, compileInstruction, loadContext) {
-    var _this12 = this;
+    var _this11 = this;
 
     loadContext = loadContext || new ResourceLoadContext();
     compileInstruction = compileInstruction || ViewCompileInstruction.normal;
 
     moduleIds = moduleIds.map(function (x) {
-      return _this12._applyLoaderPlugin(x);
+      return _this11._applyLoaderPlugin(x);
     });
 
     return this.loader.loadAllModules(moduleIds).then(function (imports) {
@@ -3277,8 +3269,8 @@ var ViewEngine = exports.ViewEngine = (_dec8 = (0, _aureliaDependencyInjection.i
       var normalizedId = void 0;
       var current = void 0;
       var associatedModule = void 0;
-      var container = _this12.container;
-      var moduleAnalyzer = _this12.moduleAnalyzer;
+      var container = _this11.container;
+      var moduleAnalyzer = _this11.moduleAnalyzer;
       var allAnalysis = new Array(imports.length);
 
       for (i = 0, ii = imports.length; i < ii; ++i) {
@@ -3565,16 +3557,18 @@ var BehaviorPropertyObserver = exports.BehaviorPropertyObserver = (_dec9 = (0, _
 }()) || _class16);
 
 
-function getObserver(behavior, instance, name) {
+function getObserver(instance, name) {
   var lookup = instance.__observers__;
 
   if (lookup === undefined) {
-    if (!behavior.isInitialized) {
-      behavior.initialize(_aureliaDependencyInjection.Container.instance || new _aureliaDependencyInjection.Container(), instance.constructor);
+    var ctor = Object.getPrototypeOf(instance).constructor;
+    var _behavior = _aureliaMetadata.metadata.get(_aureliaMetadata.metadata.resource, ctor);
+    if (!_behavior.isInitialized) {
+      _behavior.initialize(_aureliaDependencyInjection.Container.instance || new _aureliaDependencyInjection.Container(), instance.constructor);
     }
 
-    lookup = behavior.observerLocator.getOrCreateObserversLookup(instance);
-    behavior._ensurePropertiesDefined(instance, lookup);
+    lookup = _behavior.observerLocator.getOrCreateObserversLookup(instance);
+    _behavior._ensurePropertiesDefined(instance, lookup);
   }
 
   return lookup[name];
@@ -3606,13 +3600,13 @@ var BindableProperty = exports.BindableProperty = function () {
 
     if (descriptor) {
       this.descriptor = descriptor;
-      return this._configureDescriptor(behavior, descriptor);
+      return this._configureDescriptor(descriptor);
     }
 
     return undefined;
   };
 
-  BindableProperty.prototype._configureDescriptor = function _configureDescriptor(behavior, descriptor) {
+  BindableProperty.prototype._configureDescriptor = function _configureDescriptor(descriptor) {
     var name = this.name;
 
     descriptor.configurable = true;
@@ -3631,15 +3625,15 @@ var BindableProperty = exports.BindableProperty = function () {
     }
 
     descriptor.get = function () {
-      return getObserver(behavior, this, name).getValue();
+      return getObserver(this, name).getValue();
     };
 
     descriptor.set = function (value) {
-      getObserver(behavior, this, name).setValue(value);
+      getObserver(this, name).setValue(value);
     };
 
     descriptor.get.getObserver = function (obj) {
-      return getObserver(behavior, obj, name);
+      return getObserver(obj, name);
     };
 
     return descriptor;
@@ -3911,18 +3905,20 @@ var HtmlBehaviorResource = exports.HtmlBehaviorResource = function () {
       for (i = 0, ii = properties.length; i < ii; ++i) {
         properties[i].defineOn(target, this);
       }
+
+      this._copyInheritedProperties(container, target);
     }
   };
 
   HtmlBehaviorResource.prototype.register = function register(registry, name) {
-    var _this13 = this;
+    var _this12 = this;
 
     if (this.attributeName !== null) {
       registry.registerAttribute(name || this.attributeName, this, this.attributeName);
 
       if (Array.isArray(this.aliases)) {
         this.aliases.forEach(function (alias) {
-          registry.registerAttribute(alias, _this13, _this13.attributeName);
+          registry.registerAttribute(alias, _this12, _this12.attributeName);
         });
       }
     }
@@ -3933,7 +3929,7 @@ var HtmlBehaviorResource = exports.HtmlBehaviorResource = function () {
   };
 
   HtmlBehaviorResource.prototype.load = function load(container, target, loadContext, viewStrategy, transientView) {
-    var _this14 = this;
+    var _this13 = this;
 
     var options = void 0;
 
@@ -3946,8 +3942,8 @@ var HtmlBehaviorResource = exports.HtmlBehaviorResource = function () {
       }
 
       return viewStrategy.loadViewFactory(container.get(ViewEngine), options, loadContext, target).then(function (viewFactory) {
-        if (!transientView || !_this14.viewFactory) {
-          _this14.viewFactory = viewFactory;
+        if (!transientView || !_this13.viewFactory) {
+          _this13.viewFactory = viewFactory;
         }
 
         return viewFactory;
@@ -4139,6 +4135,43 @@ var HtmlBehaviorResource = exports.HtmlBehaviorResource = function () {
     }
   };
 
+  HtmlBehaviorResource.prototype._copyInheritedProperties = function _copyInheritedProperties(container, target) {
+    var _this14 = this;
+
+    var behavior = void 0,
+        derived = target;
+    while (true) {
+      var proto = Object.getPrototypeOf(target.prototype);
+      target = proto && proto.constructor;
+      if (!target) {
+        return;
+      }
+      behavior = _aureliaMetadata.metadata.getOwn(_aureliaMetadata.metadata.resource, target);
+      if (behavior) {
+        break;
+      }
+    }
+    behavior.initialize(container, target);
+
+    var _loop = function _loop(_i8, _ii8) {
+      var prop = behavior.properties[_i8];
+
+      if (_this14.properties.some(function (p) {
+        return p.name === prop.name;
+      })) {
+        return 'continue';
+      }
+
+      new BindableProperty(prop).registerWith(derived, _this14);
+    };
+
+    for (var _i8 = 0, _ii8 = behavior.properties.length; _i8 < _ii8; ++_i8) {
+      var _ret = _loop(_i8, _ii8);
+
+      if (_ret === 'continue') continue;
+    }
+  };
+
   return HtmlBehaviorResource;
 }();
 
@@ -4207,8 +4240,8 @@ function onChildChange(mutations, observer) {
   var bindersLength = binders.length;
   var groupedMutations = new Map();
 
-  for (var _i8 = 0, _ii8 = mutations.length; _i8 < _ii8; ++_i8) {
-    var record = mutations[_i8];
+  for (var _i9 = 0, _ii9 = mutations.length; _i9 < _ii9; ++_i9) {
+    var record = mutations[_i9];
     var added = record.addedNodes;
     var removed = record.removedNodes;
 
@@ -4276,8 +4309,8 @@ var ChildObserverBinder = function () {
       if (assignedSlot && assignedSlot.projectFromAnchors) {
         var anchors = assignedSlot.projectFromAnchors;
 
-        for (var _i9 = 0, _ii9 = anchors.length; _i9 < _ii9; ++_i9) {
-          if (anchors[_i9].auOwnerView === contentView) {
+        for (var _i10 = 0, _ii10 = anchors.length; _i10 < _ii10; ++_i10) {
+          if (anchors[_i10].auOwnerView === contentView) {
             return true;
           }
         }

--- a/dist/es2015/aurelia-templating.js
+++ b/dist/es2015/aurelia-templating.js
@@ -612,7 +612,7 @@ export let ViewLocator = (_temp2 = _class7 = class ViewLocator {
 }, _class7.viewStrategyMetadataKey = 'aurelia:view-strategy', _temp2);
 
 function mi(name) {
-  throw new Error(`BindingLanguage must implement ${ name }().`);
+  throw new Error(`BindingLanguage must implement ${name}().`);
 }
 
 export let BindingLanguage = class BindingLanguage {
@@ -1042,7 +1042,7 @@ function register(lookup, name, resource, type) {
   let existing = lookup[name];
   if (existing) {
     if (existing !== resource) {
-      throw new Error(`Attempted to register ${ type } when one with the same name already exists. Name: ${ name }.`);
+      throw new Error(`Attempted to register ${type} when one with the same name already exists. Name: ${name}.`);
     }
 
     return;
@@ -2964,7 +2964,7 @@ export let ViewEngine = (_dec8 = inject(Loader, Container, ViewCompiler, ModuleA
 
     importIds = dependencies.map(x => x.src);
     names = dependencies.map(x => x.name);
-    logger.debug(`importing resources for ${ registryEntry.address }`, importIds);
+    logger.debug(`importing resources for ${registryEntry.address}`, importIds);
 
     if (target) {
       let viewModelRequires = metadata.get(ViewEngine.viewModelRequireMetadataKey, target);
@@ -2979,7 +2979,7 @@ export let ViewEngine = (_dec8 = inject(Loader, Container, ViewCompiler, ModuleA
             names.push(req.as);
           }
         }
-        logger.debug(`importing ViewModel resources for ${ compileInstruction.associatedModuleId }`, importIds.slice(templateImportCount));
+        logger.debug(`importing ViewModel resources for ${compileInstruction.associatedModuleId}`, importIds.slice(templateImportCount));
       }
     }
 
@@ -2992,7 +2992,7 @@ export let ViewEngine = (_dec8 = inject(Loader, Container, ViewCompiler, ModuleA
       let resourceModule = this.moduleAnalyzer.analyze(normalizedId, viewModelModule, moduleMember);
 
       if (!resourceModule.mainResource) {
-        throw new Error(`No view model found in module "${ moduleImport }".`);
+        throw new Error(`No view model found in module "${moduleImport}".`);
       }
 
       resourceModule.initialize(this.container);
@@ -3289,10 +3289,12 @@ export let BehaviorPropertyObserver = (_dec9 = subscriberCollection(), _dec9(_cl
   }
 }) || _class16);
 
-function getObserver(behavior, instance, name) {
+function getObserver(instance, name) {
   let lookup = instance.__observers__;
 
   if (lookup === undefined) {
+    let ctor = Object.getPrototypeOf(instance).constructor;
+    let behavior = metadata.get(metadata.resource, ctor);
     if (!behavior.isInitialized) {
       behavior.initialize(Container.instance || new Container(), instance.constructor);
     }
@@ -3328,13 +3330,13 @@ export let BindableProperty = class BindableProperty {
 
     if (descriptor) {
       this.descriptor = descriptor;
-      return this._configureDescriptor(behavior, descriptor);
+      return this._configureDescriptor(descriptor);
     }
 
     return undefined;
   }
 
-  _configureDescriptor(behavior, descriptor) {
+  _configureDescriptor(descriptor) {
     let name = this.name;
 
     descriptor.configurable = true;
@@ -3353,15 +3355,15 @@ export let BindableProperty = class BindableProperty {
     }
 
     descriptor.get = function () {
-      return getObserver(behavior, this, name).getValue();
+      return getObserver(this, name).getValue();
     };
 
     descriptor.set = function (value) {
-      getObserver(behavior, this, name).setValue(value);
+      getObserver(this, name).setValue(value);
     };
 
     descriptor.get.getObserver = function (obj) {
-      return getObserver(behavior, obj, name);
+      return getObserver(obj, name);
     };
 
     return descriptor;
@@ -3406,7 +3408,7 @@ export let BindableProperty = class BindableProperty {
     } else if ('propertyChanged' in viewModel) {
       selfSubscriber = (newValue, oldValue) => viewModel.propertyChanged(name, newValue, oldValue);
     } else if (changeHandlerName !== null) {
-      throw new Error(`Change handler ${ changeHandlerName } was specified but not declared on the class.`);
+      throw new Error(`Change handler ${changeHandlerName} was specified but not declared on the class.`);
     }
 
     if (defaultValue !== undefined) {
@@ -3621,6 +3623,8 @@ export let HtmlBehaviorResource = class HtmlBehaviorResource {
       for (i = 0, ii = properties.length; i < ii; ++i) {
         properties[i].defineOn(target, this);
       }
+
+      this._copyInheritedProperties(container, target);
     }
   }
 
@@ -3842,6 +3846,32 @@ export let HtmlBehaviorResource = class HtmlBehaviorResource {
       if (observer !== undefined) {
         lookup[observer.propertyName] = observer;
       }
+    }
+  }
+
+  _copyInheritedProperties(container, target) {
+    let behavior,
+        derived = target;
+    while (true) {
+      let proto = Object.getPrototypeOf(target.prototype);
+      target = proto && proto.constructor;
+      if (!target) {
+        return;
+      }
+      behavior = metadata.getOwn(metadata.resource, target);
+      if (behavior) {
+        break;
+      }
+    }
+    behavior.initialize(container, target);
+    for (let i = 0, ii = behavior.properties.length; i < ii; ++i) {
+      let prop = behavior.properties[i];
+
+      if (this.properties.some(p => p.name === prop.name)) {
+        continue;
+      }
+
+      new BindableProperty(prop).registerWith(derived, this);
     }
   }
 };
@@ -4280,7 +4310,7 @@ export let ElementConfigResource = class ElementConfigResource {
 function validateBehaviorName(name, type) {
   if (/[A-Z]/.test(name)) {
     let newName = _hyphenate(name);
-    LogManager.getLogger('templating').warn(`'${ name }' is not a valid ${ type } name and has been converted to '${ newName }'. Upper-case letters are not allowed because the DOM is not case-sensitive.`);
+    LogManager.getLogger('templating').warn(`'${name}' is not a valid ${type} name and has been converted to '${newName}'. Upper-case letters are not allowed because the DOM is not case-sensitive.`);
     return newName;
   }
   return name;

--- a/dist/native-modules/aurelia-templating.js
+++ b/dist/native-modules/aurelia-templating.js
@@ -1,8 +1,8 @@
 var _createClass = function () { function defineProperties(target, props) { for (var i = 0; i < props.length; i++) { var descriptor = props[i]; descriptor.enumerable = descriptor.enumerable || false; descriptor.configurable = true; if ("value" in descriptor) descriptor.writable = true; Object.defineProperty(target, descriptor.key, descriptor); } } return function (Constructor, protoProps, staticProps) { if (protoProps) defineProperties(Constructor.prototype, protoProps); if (staticProps) defineProperties(Constructor, staticProps); return Constructor; }; }();
 
-var _class, _temp, _dec, _class2, _dec2, _class3, _dec3, _class4, _dec4, _class5, _dec5, _class6, _class7, _temp2, _dec6, _class8, _class9, _temp3, _class11, _dec7, _class13, _dec8, _class14, _class15, _temp4, _dec9, _class16, _dec10, _class17, _dec11, _class18;
-
 var _typeof = typeof Symbol === "function" && typeof Symbol.iterator === "symbol" ? function (obj) { return typeof obj; } : function (obj) { return obj && typeof Symbol === "function" && obj.constructor === Symbol && obj !== Symbol.prototype ? "symbol" : typeof obj; };
+
+var _class, _temp, _dec, _class2, _dec2, _class3, _dec3, _class4, _dec4, _class5, _dec5, _class6, _class7, _temp2, _dec6, _class8, _class9, _temp3, _class11, _dec7, _class13, _dec8, _class14, _class15, _temp4, _dec9, _class16, _dec10, _class17, _dec11, _class18;
 
 
 
@@ -261,22 +261,14 @@ export var ElementEvents = function () {
   };
 
   ElementEvents.prototype.subscribeOnce = function subscribeOnce(eventName, handler) {
-    var _this3 = this;
-
     var bubbles = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
 
     if (handler && typeof handler === 'function') {
-      var _ret = function () {
-        var _handler = function _handler(event) {
-          handler(event);
-          _handler.dispose();
-        };
-        return {
-          v: _this3.subscribe(eventName, _handler, bubbles)
-        };
-      }();
-
-      if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
+      var _handler = function _handler(event) {
+        handler(event);
+        _handler.dispose();
+      };
+      return this.subscribe(eventName, _handler, bubbles);
     }
 
     return undefined;
@@ -1707,7 +1699,7 @@ export var ViewSlot = function () {
   };
 
   ViewSlot.prototype.removeMany = function removeMany(viewsToRemove, returnToCache, skipAnimation) {
-    var _this4 = this;
+    var _this3 = this;
 
     var children = this.children;
     var ii = viewsToRemove.length;
@@ -1720,7 +1712,7 @@ export var ViewSlot = function () {
         return;
       }
 
-      var animation = _this4.animateView(child, 'leave');
+      var animation = _this3.animateView(child, 'leave');
       if (animation) {
         rmPromises.push(animation.then(function () {
           return child.removeNodes();
@@ -1731,7 +1723,7 @@ export var ViewSlot = function () {
     });
 
     var removeAction = function removeAction() {
-      if (_this4.isAttached) {
+      if (_this3.isAttached) {
         for (i = 0; i < ii; ++i) {
           viewsToRemove[i].detached();
         }
@@ -1761,16 +1753,16 @@ export var ViewSlot = function () {
   };
 
   ViewSlot.prototype.removeAt = function removeAt(index, returnToCache, skipAnimation) {
-    var _this5 = this;
+    var _this4 = this;
 
     var view = this.children[index];
 
     var removeAction = function removeAction() {
-      index = _this5.children.indexOf(view);
+      index = _this4.children.indexOf(view);
       view.removeNodes();
-      _this5.children.splice(index, 1);
+      _this4.children.splice(index, 1);
 
-      if (_this5.isAttached) {
+      if (_this4.isAttached) {
         view.detached();
       }
 
@@ -1794,7 +1786,7 @@ export var ViewSlot = function () {
   };
 
   ViewSlot.prototype.removeAll = function removeAll(returnToCache, skipAnimation) {
-    var _this6 = this;
+    var _this5 = this;
 
     var children = this.children;
     var ii = children.length;
@@ -1807,7 +1799,7 @@ export var ViewSlot = function () {
         return;
       }
 
-      var animation = _this6.animateView(child, 'leave');
+      var animation = _this5.animateView(child, 'leave');
       if (animation) {
         rmPromises.push(animation.then(function () {
           return child.removeNodes();
@@ -1818,7 +1810,7 @@ export var ViewSlot = function () {
     });
 
     var removeAction = function removeAction() {
-      if (_this6.isAttached) {
+      if (_this5.isAttached) {
         for (i = 0; i < ii; ++i) {
           children[i].detached();
         }
@@ -1834,7 +1826,7 @@ export var ViewSlot = function () {
         }
       }
 
-      _this6.children = [];
+      _this5.children = [];
     };
 
     if (rmPromises.length > 0) {
@@ -1881,7 +1873,7 @@ export var ViewSlot = function () {
   };
 
   ViewSlot.prototype.projectTo = function projectTo(slots) {
-    var _this7 = this;
+    var _this6 = this;
 
     this.projectToSlots = slots;
     this.add = this._projectionAdd;
@@ -1892,7 +1884,7 @@ export var ViewSlot = function () {
     this.removeMany = this._projectionRemoveMany;
     this.removeAll = this._projectionRemoveAll;
     this.children.forEach(function (view) {
-      return ShadowDOM.distributeView(view, slots, _this7);
+      return ShadowDOM.distributeView(view, slots, _this6);
     });
   };
 
@@ -1956,10 +1948,10 @@ export var ViewSlot = function () {
   };
 
   ViewSlot.prototype._projectionRemoveMany = function _projectionRemoveMany(viewsToRemove, returnToCache) {
-    var _this8 = this;
+    var _this7 = this;
 
     viewsToRemove.forEach(function (view) {
-      return _this8.remove(view, returnToCache);
+      return _this7.remove(view, returnToCache);
     });
   };
 
@@ -3072,12 +3064,12 @@ function ensureRegistryEntry(loader, urlOrRegistryEntry) {
 
 var ProxyViewFactory = function () {
   function ProxyViewFactory(promise) {
-    var _this9 = this;
+    var _this8 = this;
 
     
 
     promise.then(function (x) {
-      return _this9.viewFactory = x;
+      return _this8.viewFactory = x;
     });
   }
 
@@ -3131,7 +3123,7 @@ export var ViewEngine = (_dec8 = inject(Loader, Container, ViewCompiler, ModuleA
   };
 
   ViewEngine.prototype.loadViewFactory = function loadViewFactory(urlOrRegistryEntry, compileInstruction, loadContext, target) {
-    var _this10 = this;
+    var _this9 = this;
 
     loadContext = loadContext || new ResourceLoadContext();
 
@@ -3151,14 +3143,14 @@ export var ViewEngine = (_dec8 = inject(Loader, Container, ViewCompiler, ModuleA
 
       loadContext.addDependency(urlOrRegistryEntry);
 
-      registryEntry.onReady = _this10.loadTemplateResources(registryEntry, compileInstruction, loadContext, target).then(function (resources) {
+      registryEntry.onReady = _this9.loadTemplateResources(registryEntry, compileInstruction, loadContext, target).then(function (resources) {
         registryEntry.resources = resources;
 
         if (registryEntry.template === null) {
           return registryEntry.factory = null;
         }
 
-        var viewFactory = _this10.viewCompiler.compile(registryEntry.template, resources, compileInstruction);
+        var viewFactory = _this9.viewCompiler.compile(registryEntry.template, resources, compileInstruction);
         return registryEntry.factory = viewFactory;
       });
 
@@ -3207,30 +3199,30 @@ export var ViewEngine = (_dec8 = inject(Loader, Container, ViewCompiler, ModuleA
   };
 
   ViewEngine.prototype.importViewModelResource = function importViewModelResource(moduleImport, moduleMember) {
-    var _this11 = this;
+    var _this10 = this;
 
     return this.loader.loadModule(moduleImport).then(function (viewModelModule) {
       var normalizedId = Origin.get(viewModelModule).moduleId;
-      var resourceModule = _this11.moduleAnalyzer.analyze(normalizedId, viewModelModule, moduleMember);
+      var resourceModule = _this10.moduleAnalyzer.analyze(normalizedId, viewModelModule, moduleMember);
 
       if (!resourceModule.mainResource) {
         throw new Error('No view model found in module "' + moduleImport + '".');
       }
 
-      resourceModule.initialize(_this11.container);
+      resourceModule.initialize(_this10.container);
 
       return resourceModule.mainResource;
     });
   };
 
   ViewEngine.prototype.importViewResources = function importViewResources(moduleIds, names, resources, compileInstruction, loadContext) {
-    var _this12 = this;
+    var _this11 = this;
 
     loadContext = loadContext || new ResourceLoadContext();
     compileInstruction = compileInstruction || ViewCompileInstruction.normal;
 
     moduleIds = moduleIds.map(function (x) {
-      return _this12._applyLoaderPlugin(x);
+      return _this11._applyLoaderPlugin(x);
     });
 
     return this.loader.loadAllModules(moduleIds).then(function (imports) {
@@ -3240,8 +3232,8 @@ export var ViewEngine = (_dec8 = inject(Loader, Container, ViewCompiler, ModuleA
       var normalizedId = void 0;
       var current = void 0;
       var associatedModule = void 0;
-      var container = _this12.container;
-      var moduleAnalyzer = _this12.moduleAnalyzer;
+      var container = _this11.container;
+      var moduleAnalyzer = _this11.moduleAnalyzer;
       var allAnalysis = new Array(imports.length);
 
       for (i = 0, ii = imports.length; i < ii; ++i) {
@@ -3527,16 +3519,18 @@ export var BehaviorPropertyObserver = (_dec9 = subscriberCollection(), _dec9(_cl
   return BehaviorPropertyObserver;
 }()) || _class16);
 
-function getObserver(behavior, instance, name) {
+function getObserver(instance, name) {
   var lookup = instance.__observers__;
 
   if (lookup === undefined) {
-    if (!behavior.isInitialized) {
-      behavior.initialize(Container.instance || new Container(), instance.constructor);
+    var ctor = Object.getPrototypeOf(instance).constructor;
+    var _behavior = metadata.get(metadata.resource, ctor);
+    if (!_behavior.isInitialized) {
+      _behavior.initialize(Container.instance || new Container(), instance.constructor);
     }
 
-    lookup = behavior.observerLocator.getOrCreateObserversLookup(instance);
-    behavior._ensurePropertiesDefined(instance, lookup);
+    lookup = _behavior.observerLocator.getOrCreateObserversLookup(instance);
+    _behavior._ensurePropertiesDefined(instance, lookup);
   }
 
   return lookup[name];
@@ -3568,13 +3562,13 @@ export var BindableProperty = function () {
 
     if (descriptor) {
       this.descriptor = descriptor;
-      return this._configureDescriptor(behavior, descriptor);
+      return this._configureDescriptor(descriptor);
     }
 
     return undefined;
   };
 
-  BindableProperty.prototype._configureDescriptor = function _configureDescriptor(behavior, descriptor) {
+  BindableProperty.prototype._configureDescriptor = function _configureDescriptor(descriptor) {
     var name = this.name;
 
     descriptor.configurable = true;
@@ -3593,15 +3587,15 @@ export var BindableProperty = function () {
     }
 
     descriptor.get = function () {
-      return getObserver(behavior, this, name).getValue();
+      return getObserver(this, name).getValue();
     };
 
     descriptor.set = function (value) {
-      getObserver(behavior, this, name).setValue(value);
+      getObserver(this, name).setValue(value);
     };
 
     descriptor.get.getObserver = function (obj) {
-      return getObserver(behavior, obj, name);
+      return getObserver(obj, name);
     };
 
     return descriptor;
@@ -3873,18 +3867,20 @@ export var HtmlBehaviorResource = function () {
       for (i = 0, ii = properties.length; i < ii; ++i) {
         properties[i].defineOn(target, this);
       }
+
+      this._copyInheritedProperties(container, target);
     }
   };
 
   HtmlBehaviorResource.prototype.register = function register(registry, name) {
-    var _this13 = this;
+    var _this12 = this;
 
     if (this.attributeName !== null) {
       registry.registerAttribute(name || this.attributeName, this, this.attributeName);
 
       if (Array.isArray(this.aliases)) {
         this.aliases.forEach(function (alias) {
-          registry.registerAttribute(alias, _this13, _this13.attributeName);
+          registry.registerAttribute(alias, _this12, _this12.attributeName);
         });
       }
     }
@@ -3895,7 +3891,7 @@ export var HtmlBehaviorResource = function () {
   };
 
   HtmlBehaviorResource.prototype.load = function load(container, target, loadContext, viewStrategy, transientView) {
-    var _this14 = this;
+    var _this13 = this;
 
     var options = void 0;
 
@@ -3908,8 +3904,8 @@ export var HtmlBehaviorResource = function () {
       }
 
       return viewStrategy.loadViewFactory(container.get(ViewEngine), options, loadContext, target).then(function (viewFactory) {
-        if (!transientView || !_this14.viewFactory) {
-          _this14.viewFactory = viewFactory;
+        if (!transientView || !_this13.viewFactory) {
+          _this13.viewFactory = viewFactory;
         }
 
         return viewFactory;
@@ -4101,6 +4097,43 @@ export var HtmlBehaviorResource = function () {
     }
   };
 
+  HtmlBehaviorResource.prototype._copyInheritedProperties = function _copyInheritedProperties(container, target) {
+    var _this14 = this;
+
+    var behavior = void 0,
+        derived = target;
+    while (true) {
+      var proto = Object.getPrototypeOf(target.prototype);
+      target = proto && proto.constructor;
+      if (!target) {
+        return;
+      }
+      behavior = metadata.getOwn(metadata.resource, target);
+      if (behavior) {
+        break;
+      }
+    }
+    behavior.initialize(container, target);
+
+    var _loop = function _loop(_i8, _ii8) {
+      var prop = behavior.properties[_i8];
+
+      if (_this14.properties.some(function (p) {
+        return p.name === prop.name;
+      })) {
+        return 'continue';
+      }
+
+      new BindableProperty(prop).registerWith(derived, _this14);
+    };
+
+    for (var _i8 = 0, _ii8 = behavior.properties.length; _i8 < _ii8; ++_i8) {
+      var _ret = _loop(_i8, _ii8);
+
+      if (_ret === 'continue') continue;
+    }
+  };
+
   return HtmlBehaviorResource;
 }();
 
@@ -4169,8 +4202,8 @@ function onChildChange(mutations, observer) {
   var bindersLength = binders.length;
   var groupedMutations = new Map();
 
-  for (var _i8 = 0, _ii8 = mutations.length; _i8 < _ii8; ++_i8) {
-    var record = mutations[_i8];
+  for (var _i9 = 0, _ii9 = mutations.length; _i9 < _ii9; ++_i9) {
+    var record = mutations[_i9];
     var added = record.addedNodes;
     var removed = record.removedNodes;
 
@@ -4238,8 +4271,8 @@ var ChildObserverBinder = function () {
       if (assignedSlot && assignedSlot.projectFromAnchors) {
         var anchors = assignedSlot.projectFromAnchors;
 
-        for (var _i9 = 0, _ii9 = anchors.length; _i9 < _ii9; ++_i9) {
-          if (anchors[_i9].auOwnerView === contentView) {
+        for (var _i10 = 0, _ii10 = anchors.length; _i10 < _ii10; ++_i10) {
+          if (anchors[_i10].auOwnerView === contentView) {
             return true;
           }
         }

--- a/dist/system/aurelia-templating.js
+++ b/dist/system/aurelia-templating.js
@@ -3,7 +3,7 @@
 System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-path', 'aurelia-loader', 'aurelia-dependency-injection', 'aurelia-binding', 'aurelia-task-queue'], function (_export, _context) {
   "use strict";
 
-  var LogManager, metadata, Origin, protocol, DOM, PLATFORM, FEATURE, relativeToFile, TemplateRegistryEntry, Loader, inject, Container, resolver, Binding, createOverrideContext, ValueConverterResource, BindingBehaviorResource, subscriberCollection, bindingMode, ObserverLocator, EventManager, TaskQueue, _createClass, _class, _temp, _dec, _class2, _dec2, _class3, _dec3, _class4, _dec4, _class5, _dec5, _class6, _class7, _temp2, _dec6, _class8, _class9, _temp3, _class11, _dec7, _class13, _dec8, _class14, _class15, _temp4, _dec9, _class16, _dec10, _class17, _dec11, _class18, _typeof, animationEvent, Animator, CompositionTransactionNotifier, CompositionTransactionOwnershipToken, CompositionTransaction, capitalMatcher, ViewEngineHooksResource, ElementEvents, ResourceLoadContext, ViewCompileInstruction, BehaviorInstruction, TargetInstruction, viewStrategy, RelativeViewStrategy, ConventionalViewStrategy, NoViewStrategy, TemplateRegistryViewStrategy, InlineViewStrategy, ViewLocator, BindingLanguage, noNodes, SlotCustomAttribute, PassThroughSlot, ShadowSlot, ShadowDOM, ViewResources, View, ViewSlot, ProviderResolver, providerResolverInstance, BoundViewFactory, ViewFactory, nextInjectorId, lastAUTargetID, ViewCompiler, ResourceModule, ResourceDescription, ModuleAnalyzer, logger, ProxyViewFactory, ViewEngine, Controller, BehaviorPropertyObserver, BindableProperty, lastProviderId, HtmlBehaviorResource, ChildObserver, noMutations, ChildObserverBinder, SwapStrategies, CompositionEngine, ElementConfigResource, defaultShadowDOMOptions, TemplatingEngine;
+  var LogManager, metadata, Origin, protocol, DOM, PLATFORM, FEATURE, relativeToFile, TemplateRegistryEntry, Loader, inject, Container, resolver, Binding, createOverrideContext, ValueConverterResource, BindingBehaviorResource, subscriberCollection, bindingMode, ObserverLocator, EventManager, TaskQueue, _createClass, _typeof, _class, _temp, _dec, _class2, _dec2, _class3, _dec3, _class4, _dec4, _class5, _dec5, _class6, _class7, _temp2, _dec6, _class8, _class9, _temp3, _class11, _dec7, _class13, _dec8, _class14, _class15, _temp4, _dec9, _class16, _dec10, _class17, _dec11, _class18, animationEvent, Animator, CompositionTransactionNotifier, CompositionTransactionOwnershipToken, CompositionTransaction, capitalMatcher, ViewEngineHooksResource, ElementEvents, ResourceLoadContext, ViewCompileInstruction, BehaviorInstruction, TargetInstruction, viewStrategy, RelativeViewStrategy, ConventionalViewStrategy, NoViewStrategy, TemplateRegistryViewStrategy, InlineViewStrategy, ViewLocator, BindingLanguage, noNodes, SlotCustomAttribute, PassThroughSlot, ShadowSlot, ShadowDOM, ViewResources, View, ViewSlot, ProviderResolver, providerResolverInstance, BoundViewFactory, ViewFactory, nextInjectorId, lastAUTargetID, ViewCompiler, ResourceModule, ResourceDescription, ModuleAnalyzer, logger, ProxyViewFactory, ViewEngine, Controller, BehaviorPropertyObserver, BindableProperty, lastProviderId, HtmlBehaviorResource, ChildObserver, noMutations, ChildObserverBinder, SwapStrategies, CompositionEngine, ElementConfigResource, defaultShadowDOMOptions, TemplatingEngine;
 
   
 
@@ -364,16 +364,18 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
     return loader.loadTemplate(urlOrRegistryEntry);
   }
 
-  function getObserver(behavior, instance, name) {
+  function getObserver(instance, name) {
     var lookup = instance.__observers__;
 
     if (lookup === undefined) {
-      if (!behavior.isInitialized) {
-        behavior.initialize(Container.instance || new Container(), instance.constructor);
+      var ctor = Object.getPrototypeOf(instance).constructor;
+      var _behavior = metadata.get(metadata.resource, ctor);
+      if (!_behavior.isInitialized) {
+        _behavior.initialize(Container.instance || new Container(), instance.constructor);
       }
 
-      lookup = behavior.observerLocator.getOrCreateObserversLookup(instance);
-      behavior._ensurePropertiesDefined(instance, lookup);
+      lookup = _behavior.observerLocator.getOrCreateObserversLookup(instance);
+      _behavior._ensurePropertiesDefined(instance, lookup);
     }
 
     return lookup[name];
@@ -438,8 +440,8 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
     var bindersLength = binders.length;
     var groupedMutations = new Map();
 
-    for (var _i8 = 0, _ii8 = mutations.length; _i8 < _ii8; ++_i8) {
-      var record = mutations[_i8];
+    for (var _i9 = 0, _ii9 = mutations.length; _i9 < _ii9; ++_i9) {
+      var record = mutations[_i9];
       var added = record.addedNodes;
       var removed = record.removedNodes;
 
@@ -1005,22 +1007,14 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
         };
 
         ElementEvents.prototype.subscribeOnce = function subscribeOnce(eventName, handler) {
-          var _this3 = this;
-
           var bubbles = arguments.length > 2 && arguments[2] !== undefined ? arguments[2] : true;
 
           if (handler && typeof handler === 'function') {
-            var _ret = function () {
-              var _handler = function _handler(event) {
-                handler(event);
-                _handler.dispose();
-              };
-              return {
-                v: _this3.subscribe(eventName, _handler, bubbles)
-              };
-            }();
-
-            if ((typeof _ret === 'undefined' ? 'undefined' : _typeof(_ret)) === "object") return _ret.v;
+            var _handler = function _handler(event) {
+              handler(event);
+              _handler.dispose();
+            };
+            return this.subscribe(eventName, _handler, bubbles);
           }
 
           return undefined;
@@ -2450,7 +2444,7 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
         };
 
         ViewSlot.prototype.removeMany = function removeMany(viewsToRemove, returnToCache, skipAnimation) {
-          var _this4 = this;
+          var _this3 = this;
 
           var children = this.children;
           var ii = viewsToRemove.length;
@@ -2463,7 +2457,7 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
               return;
             }
 
-            var animation = _this4.animateView(child, 'leave');
+            var animation = _this3.animateView(child, 'leave');
             if (animation) {
               rmPromises.push(animation.then(function () {
                 return child.removeNodes();
@@ -2474,7 +2468,7 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
           });
 
           var removeAction = function removeAction() {
-            if (_this4.isAttached) {
+            if (_this3.isAttached) {
               for (i = 0; i < ii; ++i) {
                 viewsToRemove[i].detached();
               }
@@ -2504,16 +2498,16 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
         };
 
         ViewSlot.prototype.removeAt = function removeAt(index, returnToCache, skipAnimation) {
-          var _this5 = this;
+          var _this4 = this;
 
           var view = this.children[index];
 
           var removeAction = function removeAction() {
-            index = _this5.children.indexOf(view);
+            index = _this4.children.indexOf(view);
             view.removeNodes();
-            _this5.children.splice(index, 1);
+            _this4.children.splice(index, 1);
 
-            if (_this5.isAttached) {
+            if (_this4.isAttached) {
               view.detached();
             }
 
@@ -2537,7 +2531,7 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
         };
 
         ViewSlot.prototype.removeAll = function removeAll(returnToCache, skipAnimation) {
-          var _this6 = this;
+          var _this5 = this;
 
           var children = this.children;
           var ii = children.length;
@@ -2550,7 +2544,7 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
               return;
             }
 
-            var animation = _this6.animateView(child, 'leave');
+            var animation = _this5.animateView(child, 'leave');
             if (animation) {
               rmPromises.push(animation.then(function () {
                 return child.removeNodes();
@@ -2561,7 +2555,7 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
           });
 
           var removeAction = function removeAction() {
-            if (_this6.isAttached) {
+            if (_this5.isAttached) {
               for (i = 0; i < ii; ++i) {
                 children[i].detached();
               }
@@ -2577,7 +2571,7 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
               }
             }
 
-            _this6.children = [];
+            _this5.children = [];
           };
 
           if (rmPromises.length > 0) {
@@ -2624,7 +2618,7 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
         };
 
         ViewSlot.prototype.projectTo = function projectTo(slots) {
-          var _this7 = this;
+          var _this6 = this;
 
           this.projectToSlots = slots;
           this.add = this._projectionAdd;
@@ -2635,7 +2629,7 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
           this.removeMany = this._projectionRemoveMany;
           this.removeAll = this._projectionRemoveAll;
           this.children.forEach(function (view) {
-            return ShadowDOM.distributeView(view, slots, _this7);
+            return ShadowDOM.distributeView(view, slots, _this6);
           });
         };
 
@@ -2699,10 +2693,10 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
         };
 
         ViewSlot.prototype._projectionRemoveMany = function _projectionRemoveMany(viewsToRemove, returnToCache) {
-          var _this8 = this;
+          var _this7 = this;
 
           viewsToRemove.forEach(function (view) {
-            return _this8.remove(view, returnToCache);
+            return _this7.remove(view, returnToCache);
           });
         };
 
@@ -3537,12 +3531,12 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
 
       ProxyViewFactory = function () {
         function ProxyViewFactory(promise) {
-          var _this9 = this;
+          var _this8 = this;
 
           
 
           promise.then(function (x) {
-            return _this9.viewFactory = x;
+            return _this8.viewFactory = x;
           });
         }
 
@@ -3596,7 +3590,7 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
         };
 
         ViewEngine.prototype.loadViewFactory = function loadViewFactory(urlOrRegistryEntry, compileInstruction, loadContext, target) {
-          var _this10 = this;
+          var _this9 = this;
 
           loadContext = loadContext || new ResourceLoadContext();
 
@@ -3616,14 +3610,14 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
 
             loadContext.addDependency(urlOrRegistryEntry);
 
-            registryEntry.onReady = _this10.loadTemplateResources(registryEntry, compileInstruction, loadContext, target).then(function (resources) {
+            registryEntry.onReady = _this9.loadTemplateResources(registryEntry, compileInstruction, loadContext, target).then(function (resources) {
               registryEntry.resources = resources;
 
               if (registryEntry.template === null) {
                 return registryEntry.factory = null;
               }
 
-              var viewFactory = _this10.viewCompiler.compile(registryEntry.template, resources, compileInstruction);
+              var viewFactory = _this9.viewCompiler.compile(registryEntry.template, resources, compileInstruction);
               return registryEntry.factory = viewFactory;
             });
 
@@ -3672,30 +3666,30 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
         };
 
         ViewEngine.prototype.importViewModelResource = function importViewModelResource(moduleImport, moduleMember) {
-          var _this11 = this;
+          var _this10 = this;
 
           return this.loader.loadModule(moduleImport).then(function (viewModelModule) {
             var normalizedId = Origin.get(viewModelModule).moduleId;
-            var resourceModule = _this11.moduleAnalyzer.analyze(normalizedId, viewModelModule, moduleMember);
+            var resourceModule = _this10.moduleAnalyzer.analyze(normalizedId, viewModelModule, moduleMember);
 
             if (!resourceModule.mainResource) {
               throw new Error('No view model found in module "' + moduleImport + '".');
             }
 
-            resourceModule.initialize(_this11.container);
+            resourceModule.initialize(_this10.container);
 
             return resourceModule.mainResource;
           });
         };
 
         ViewEngine.prototype.importViewResources = function importViewResources(moduleIds, names, resources, compileInstruction, loadContext) {
-          var _this12 = this;
+          var _this11 = this;
 
           loadContext = loadContext || new ResourceLoadContext();
           compileInstruction = compileInstruction || ViewCompileInstruction.normal;
 
           moduleIds = moduleIds.map(function (x) {
-            return _this12._applyLoaderPlugin(x);
+            return _this11._applyLoaderPlugin(x);
           });
 
           return this.loader.loadAllModules(moduleIds).then(function (imports) {
@@ -3705,8 +3699,8 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
             var normalizedId = void 0;
             var current = void 0;
             var associatedModule = void 0;
-            var container = _this12.container;
-            var moduleAnalyzer = _this12.moduleAnalyzer;
+            var container = _this11.container;
+            var moduleAnalyzer = _this11.moduleAnalyzer;
             var allAnalysis = new Array(imports.length);
 
             for (i = 0, ii = imports.length; i < ii; ++i) {
@@ -4024,13 +4018,13 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
 
           if (descriptor) {
             this.descriptor = descriptor;
-            return this._configureDescriptor(behavior, descriptor);
+            return this._configureDescriptor(descriptor);
           }
 
           return undefined;
         };
 
-        BindableProperty.prototype._configureDescriptor = function _configureDescriptor(behavior, descriptor) {
+        BindableProperty.prototype._configureDescriptor = function _configureDescriptor(descriptor) {
           var name = this.name;
 
           descriptor.configurable = true;
@@ -4049,15 +4043,15 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
           }
 
           descriptor.get = function () {
-            return getObserver(behavior, this, name).getValue();
+            return getObserver(this, name).getValue();
           };
 
           descriptor.set = function (value) {
-            getObserver(behavior, this, name).setValue(value);
+            getObserver(this, name).setValue(value);
           };
 
           descriptor.get.getObserver = function (obj) {
-            return getObserver(behavior, obj, name);
+            return getObserver(obj, name);
           };
 
           return descriptor;
@@ -4322,18 +4316,20 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
             for (i = 0, ii = properties.length; i < ii; ++i) {
               properties[i].defineOn(target, this);
             }
+
+            this._copyInheritedProperties(container, target);
           }
         };
 
         HtmlBehaviorResource.prototype.register = function register(registry, name) {
-          var _this13 = this;
+          var _this12 = this;
 
           if (this.attributeName !== null) {
             registry.registerAttribute(name || this.attributeName, this, this.attributeName);
 
             if (Array.isArray(this.aliases)) {
               this.aliases.forEach(function (alias) {
-                registry.registerAttribute(alias, _this13, _this13.attributeName);
+                registry.registerAttribute(alias, _this12, _this12.attributeName);
               });
             }
           }
@@ -4344,7 +4340,7 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
         };
 
         HtmlBehaviorResource.prototype.load = function load(container, target, loadContext, viewStrategy, transientView) {
-          var _this14 = this;
+          var _this13 = this;
 
           var options = void 0;
 
@@ -4357,8 +4353,8 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
             }
 
             return viewStrategy.loadViewFactory(container.get(ViewEngine), options, loadContext, target).then(function (viewFactory) {
-              if (!transientView || !_this14.viewFactory) {
-                _this14.viewFactory = viewFactory;
+              if (!transientView || !_this13.viewFactory) {
+                _this13.viewFactory = viewFactory;
               }
 
               return viewFactory;
@@ -4550,6 +4546,43 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
           }
         };
 
+        HtmlBehaviorResource.prototype._copyInheritedProperties = function _copyInheritedProperties(container, target) {
+          var _this14 = this;
+
+          var behavior = void 0,
+              derived = target;
+          while (true) {
+            var proto = Object.getPrototypeOf(target.prototype);
+            target = proto && proto.constructor;
+            if (!target) {
+              return;
+            }
+            behavior = metadata.getOwn(metadata.resource, target);
+            if (behavior) {
+              break;
+            }
+          }
+          behavior.initialize(container, target);
+
+          var _loop = function _loop(_i8, _ii8) {
+            var prop = behavior.properties[_i8];
+
+            if (_this14.properties.some(function (p) {
+              return p.name === prop.name;
+            })) {
+              return 'continue';
+            }
+
+            new BindableProperty(prop).registerWith(derived, _this14);
+          };
+
+          for (var _i8 = 0, _ii8 = behavior.properties.length; _i8 < _ii8; ++_i8) {
+            var _ret = _loop(_i8, _ii8);
+
+            if (_ret === 'continue') continue;
+          }
+        };
+
         return HtmlBehaviorResource;
       }());
 
@@ -4606,8 +4639,8 @@ System.register(['aurelia-logging', 'aurelia-metadata', 'aurelia-pal', 'aurelia-
             if (assignedSlot && assignedSlot.projectFromAnchors) {
               var anchors = assignedSlot.projectFromAnchors;
 
-              for (var _i9 = 0, _ii9 = anchors.length; _i9 < _ii9; ++_i9) {
-                if (anchors[_i9].auOwnerView === contentView) {
+              for (var _i10 = 0, _ii10 = anchors.length; _i10 < _ii10; ++_i10) {
+                if (anchors[_i10].auOwnerView === contentView) {
                   return true;
                 }
               }

--- a/doc/article/en-US/templating-html-behaviors-introduction.md
+++ b/doc/article/en-US/templating-html-behaviors-introduction.md
@@ -235,6 +235,112 @@ By default, bindable properties only allow `one-way` data binding. This means th
   </source-code>
 </code-listing>
 
+
+For our developers who love to keep their [SoCs](https://en.wikipedia.org/wiki/Separation_of_concerns) [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself), bindable properties within element components are inherited through the class hierarchy making a powerful complement to component composition with its intuitive manner for expressing the imagination.
+
+In the following example we create a generic icon button component `ib` that is integrated with [font awesome](http://fontawesome.io/).
+
+<code-listing heading="ib.js">
+  <source-code lang="ES 2015">
+    
+    import {bindable} from 'aurelia-framework'
+    
+    export class Ib{
+      @bindable icon = 'ban'
+      
+      constructor(){
+      }
+      
+      onclick(){
+        alert("Default method")
+      }
+      
+    }
+    
+  </source-code>
+</code-listing>
+
+Its generic `View` file `ib.html`
+
+<code-listing heading="ib.html">
+  <source-code lang="HTML">
+  
+    <template>
+      <i class="fa fa-${icon}" click.delegate="onclick" />
+    </template>
+  </source-code>
+</code-listing>
+
+Our following component that extends the generic button and setting its default icon as well as a different base function for
+a new `add button` component family.
+
+<code-listing heading="add-button.js">
+  <source-code lang="ES 2015"/>
+    
+    import {useView, viewResources} from 'aurelia-framework'
+    import {Ib} from 'ib'
+    
+    @useView('ib.html') //with future improvement on compatibility of inheritance we'll remove the redundancy of useView
+    @viewResources('add-button.css')
+    export class AddButton extends Ib{
+      constructor(){
+        super();
+        this.icon = 'plus' //Set a default icon for add buttons
+        this.onclick = this.add //Overrides what this button's function is called
+      }
+      
+      add(){
+        alert('Base add buton')
+        console.log('Some more base add button stuff')
+      }
+      
+    }
+    
+  </source-code>
+</code-listing>
+
+Some default styling for the `add button` family in `add-button.css`
+
+<code-listing heading="add-button.css">
+  <source-code lang="CSS3"/>
+  
+    fa-icon: {
+      color: green;
+      font-weight: bold;
+      font-size: large
+    };
+        
+  </source-code>
+</code-listing>
+
+And finally our composition using both button families (Note that `ib` is only necessary as a viewResource if used within the composition)
+
+<code-listing heading="composition.js">
+  <source-code lang="ES 2015"/>
+  
+    import {viewResources} from 'aurelia-framework'
+    
+    @viewResources('ib', 'add-button', 'add-button.css') //With future improvements on compatibility of transitive resources we'll remove redundancy of viewResource imports
+    export class Composition{
+      constructor(){
+      }
+    }
+        
+  </source-code>
+</code-listing>  
+<code-listing heading="composition.html">
+  <source-code lang="HTML">
+    
+    <template>
+      <ib /> <!-- Default button use -->
+      <ib icon="cogs" /> <!-- inline binding button use -->
+      <add-button /> <!-- Default extended button use -->
+      <add-button icon="plus-square-o" /> <!-- inline binding with extended button use -->
+    </template>
+  </source-code>
+</code-listing>
+
+
 Binding with Custom Attributes is a bit more nuanced than Custom Elements in that Custom Attributes support three types of binding: single value, options binding, and dynamic options binding. In this document, we will only look at single value binding. Please check out the Custom Attribute documentation for examples of how to implement and use all three types of bindings.
 
 The `@bindable` decorator isn't used when doing single value binding with a Custom Attribute because all attributes have a `value` property by default. This is ensured by Aurelia. Instead, we implement a `valueChanged` callback function that Aurelia calls to alert us that the bound value of the Custom Attribute has changed. Aurelia will set the value to the `value` property of the Custom Attribute's ViewModel, and will pass two parameters to the `valueChanged` callback: the new value and the old value. Let's look at an example.

--- a/src/bindable-property.js
+++ b/src/bindable-property.js
@@ -2,11 +2,20 @@ import {_hyphenate} from './util';
 import {BehaviorPropertyObserver} from './behavior-property-observer';
 import {bindingMode} from 'aurelia-binding';
 import {Container} from 'aurelia-dependency-injection';
+import {metadata} from 'aurelia-metadata';
 
-function getObserver(behavior, instance, name) {
+function getObserver(instance, name) {
   let lookup = instance.__observers__;
 
   if (lookup === undefined) {
+    // We need to lookup the actual behavior for this instance, 
+    // as it might be a derived class (and behavior) rather than 
+    // the class (and behavior) that declared the property calling getObserver().
+    // This means we can't capture the behavior in property get/set/getObserver and pass it here. 
+    // Note that it's probably for the best, as passing the behavior is an overhead 
+    // that is only useful in the very first call of the first property of the instance.
+    let ctor = Object.getPrototypeOf(instance).constructor; // Playing safe here, user could have written to instance.constructor.
+    let behavior = metadata.get(metadata.resource, ctor);
     if (!behavior.isInitialized) {
       behavior.initialize(Container.instance || new Container(), instance.constructor);
     }
@@ -55,13 +64,13 @@ export class BindableProperty {
 
     if (descriptor) {
       this.descriptor = descriptor;
-      return this._configureDescriptor(behavior, descriptor);
+      return this._configureDescriptor(descriptor);
     }
 
     return undefined;
   }
 
-  _configureDescriptor(behavior: HtmlBehaviorResource, descriptor: Object): Object {
+  _configureDescriptor(descriptor: Object): Object {
     let name = this.name;
 
     descriptor.configurable = true;
@@ -80,15 +89,15 @@ export class BindableProperty {
     }
 
     descriptor.get = function() {
-      return getObserver(behavior, this, name).getValue();
+      return getObserver(this, name).getValue();
     };
 
     descriptor.set = function(value) {
-      getObserver(behavior, this, name).setValue(value);
+      getObserver(this, name).setValue(value);
     };
 
     descriptor.get.getObserver = function(obj) {
-      return getObserver(behavior, obj, name);
+      return getObserver(obj, name);
     };
 
     return descriptor;

--- a/src/html-behavior.js
+++ b/src/html-behavior.js
@@ -1,4 +1,4 @@
-import {Origin} from 'aurelia-metadata';
+import {metadata, Origin} from 'aurelia-metadata';
 import {ObserverLocator, Binding} from 'aurelia-binding';
 import {TaskQueue} from 'aurelia-task-queue';
 import {Container} from 'aurelia-dependency-injection';
@@ -155,6 +155,10 @@ export class HtmlBehaviorResource {
       for (i = 0, ii = properties.length; i < ii; ++i) {
         properties[i].defineOn(target, this);
       }
+      // Because how inherited properties would interact with the default 'value' property 
+      // in a custom attribute is not well defined yet, we only inherit properties on 
+      // custom elements, where it's not a problem.
+      this._copyInheritedProperties(container, target);
     }
   }
 
@@ -417,5 +421,36 @@ export class HtmlBehaviorResource {
         lookup[observer.propertyName] = observer;
       }
     }
+  }
+
+  _copyInheritedProperties(container: Container, target: Function) {
+    // This methods enables inherited @bindable properties.    
+    // We look for the first base class with metadata, make sure it's initialized 
+    // and copy its properties. 
+    // We don't need to walk further than the first parent with metadata because
+    // it had also inherited properties during its own initialization.
+    let behavior, derived = target;
+    while (true) {
+      let proto = Object.getPrototypeOf(target.prototype);
+      target = proto && proto.constructor;
+      if (!target) {
+        return;
+      }
+      behavior = metadata.getOwn(metadata.resource, target);
+      if (behavior) {
+        break;
+      }
+    }
+    behavior.initialize(container, target);    
+    for (let i = 0, ii = behavior.properties.length; i < ii; ++i) {
+      let prop = behavior.properties[i];
+      // Check that the property metadata was not overriden or re-defined in this class
+      if (this.properties.some(p => p.name === prop.name)) {
+        continue;
+      }
+      // We don't need to call .defineOn() for those properties because it was done
+      // on the parent prototype during initialization.
+      new BindableProperty(prop).registerWith(derived, this);
+    }    
   }
 }

--- a/test/behaviors/derived-element.js
+++ b/test/behaviors/derived-element.js
@@ -1,0 +1,15 @@
+import { bindable } from '../../src/decorators';
+import { SimpleElement } from './simple-element';
+
+export class DerivedElement extends SimpleElement {  
+}
+
+export class MoreDerivedCustomElement extends DerivedElement {
+  @bindable frob;
+
+  frobChanged() {}
+}
+
+export class OverrideCustomElement extends SimpleElement {
+  @bindable({ changeHandler: 'handleFoo' }) foo;
+}

--- a/test/inheritance.spec.js
+++ b/test/inheritance.spec.js
@@ -1,0 +1,39 @@
+import './setup';
+import {ObserverLocator} from 'aurelia-binding';
+import {Container} from 'aurelia-dependency-injection';
+import {metadata} from 'aurelia-metadata';
+import {TaskQueue} from 'aurelia-task-queue';
+import {MoreDerivedCustomElement, OverrideCustomElement} from './behaviors/derived-element';
+
+describe('Inheritance', () => {
+  let container;
+
+  beforeEach(() => {
+    container = new Container();
+    container.registerInstance(ObserverLocator, {});
+    container.registerInstance(TaskQueue, {});
+  });
+
+  it('should inherit base bindable properties', () => {
+    let behavior = getResource(MoreDerivedCustomElement);
+    behavior.initialize(container, MoreDerivedCustomElement);
+
+    expect(behavior.properties.length).toBe(3);
+    // On MoreDerivedCustomElement:
+    expect(behavior.attributes['frob'].changeHandler).toBe('frobChanged');
+    // On SimplElement:
+    expect(behavior.attributes['foo'].changeHandler).toBe('fooChanged');
+    expect(behavior.attributes['bar'].attribute).toBe('bar');
+  });
+
+  it('can override base properties', () => {
+    let behavior = getResource(OverrideCustomElement);
+    behavior.initialize(container, OverrideCustomElement);
+
+    expect(behavior.attributes['foo'].changeHandler).toBe('handleFoo');
+  });
+});
+
+function getResource(target) {
+  return metadata.getOwn(metadata.resource, target);
+}


### PR DESCRIPTION
### Overview
This PR adds support for `@bindable` properties inherited from a base class in a custom element.
This has been asked for several times, the open issue for that being #463.

The way `HtmlBehaviorResource` is used by Aurelia is unfortunately not inheritance-friendly. For this reason, this PR is very narrow in scope:
- It only adds support for `@bindable` properties. No other aspect from the base `HtmlBehaviorResource` is propagated to descendant classes.
- It only applies to custom elements. Custom attributes could easily share the same code, but we would need to define how the default `value` property would works precisely.

Additionally, the following restrictions apply:
- The derived classes need their own `HtmlBehaviorResource` metadata. So be sure to have at least one `@bindable` or `@customElement` or something like that on the derived class. Note that `@useView` is _not_ stored there.
- You need an ES6 compliant inheritance structure. In particular, it currently doesn't work with ES5 code generated from Typescript, see [this comment](https://github.com/aurelia/templating/issues/463#issuecomment-267774208) for details and workarounds. See also my `constructor` remark in the review section below.

### Usage 
Here's a trivial example of what is now possible. A base class provides some common behavior, with exposed bindable properties and two descendant classes create actual custom elements with some customizations. 
#### calculator.ts
```ts
import { bindable, useView, customElement } from 'aurelia-framework';

class CalculatorCustomElement {
  @bindable({ changeHandler: 'compute' })
  x = 0;
  @bindable({ changeHandler: 'compute' })
  y = 0;  
  result: number;
}

@useView('calculator.html')
export class AddCustomElement extends CalculatorCustomElement { 
  @bindable whatever;
  
  compute() {
    this.result = this.x + this.y;
  }
}

@customElement('multiply')  // required to give the class its own behavior
@useView('calculator.html')
export class MultiplyCustomElement extends CalculatorCustomElement {
  compute() {
    this.result = this.x * this.y;
  }
}
```
#### calculator.html
```html
<template> = ${result}</template>
```
#### app.html
```html
<template>
  <div>
    <p>2 + 3 <add x.bind=2 y.bind=3></add></p>
    <p>2 * 3 <multiply x.bind=2 y.bind=3></multiply></p>
  </div>
</template>
```

#### Tests
I included new tests to demonstrate the changes in metadata.

That said, this is clearly not enough to check that everything works properly in practice and in all browsers, as the restrictions described above show.

I tested that the sample above works properly in ES6, and TypeScript ES5 (with patched `__extends` copied from Babel).

#### Review
The changes are small but this is a tricky part of Aurelia. To make reviewing easier I split the implementation and `dist` in two commits.

For the most part, the changes have no impact on code that doesn't use inheritance. 
For people who already use inheritance by repeating the `@bindable` metadata, this is supported (last declaration wins).

And then there's `bindable-property.js`, which you'll want to review carefully. 
I had to change the way `getObserver` install itself and especially how it finds the correct behavior. That was one part that was clearly not inheritance friendly.
Previously it found its behavior by capturing it and passing it around. I am now doing it by looking at metadata.
This is all fine, but **it assumes `prototype.constructor` is properly set**. This is the case with ES6, Typescript or Babel generated code. I don't know if Aurelia supports people writing plain ES5 for everything and not properly setting `prototype.constructor`. **That kind of code would break.**

That's all folks! 🎉 

/cc @EisenbergEffect @jdanyow 