### PR TITLE
Use default binding from primary property

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "typescript.tsdk": "./node_modules/typescript/lib"
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "typescript.tsdk": "./node_modules/typescript/lib"
+}

--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -205,7 +205,7 @@ export class ViewCompiler {
             // associate the attribute value with the name of the default bindable property
             // (otherwise it will remain associated with "value")
             if (info.command && (info.command !== 'options') && type.primaryProperty) {
-              let primaryProperty = type.primaryProperty;
+              const primaryProperty = type.primaryProperty;
               attrName = info.attrName = primaryProperty.name;
               // note that the defaultBindingMode always overrides the attribute bindingMode which is only used for "single-value" custom attributes
               // when using the syntax `<div square.bind="color"></div>`
@@ -346,7 +346,7 @@ export class ViewCompiler {
             // associate the attribute value with the name of the default bindable property
             // (otherwise it will remain associated with "value")
             if (info.command && (info.command !== 'options') && type.primaryProperty) {
-              let primaryProperty = type.primaryProperty;
+              const primaryProperty = type.primaryProperty;
               attrName = info.attrName = primaryProperty.name;
               // note that the defaultBindingMode always overrides the attribute bindingMode which is only used for "single-value" custom attributes
               // when using the syntax `<div square.bind="color"></div>`

--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -342,8 +342,12 @@ export class ViewCompiler {
             // associate the attribute value with the name of the default bindable property
             // (otherwise it will remain associated with "value")
             if (info.command && (info.command !== 'options') && type.primaryProperty) {
-              attrName = info.attrName = type.primaryProperty.name;
-            }
+              let primaryProperty = type.primaryProperty;
+              attrName = info.attrName = primaryProperty.name;
+              // note that the defaultBindingMode always overrides the attribute bindingMode which is only used for "single-value" custom attributes 
+              // when using the syntax `<div square.bind="color"></div>`
+              info.defaultBindingMode = primaryProperty.defaultBindingMode;
+          }
           }
         }
       } else if (elementInstruction) { //or if this is on a custom element

--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -207,7 +207,7 @@ export class ViewCompiler {
             if (info.command && (info.command !== 'options') && type.primaryProperty) {
               let primaryProperty = type.primaryProperty;
               attrName = info.attrName = primaryProperty.name;
-              // note that the defaultBindingMode always overrides the attribute bindingMode which is only used for "single-value" custom attributes 
+              // note that the defaultBindingMode always overrides the attribute bindingMode which is only used for "single-value" custom attributes
               // when using the syntax `<div square.bind="color"></div>`
               info.defaultBindingMode = primaryProperty.defaultBindingMode;
             }
@@ -348,10 +348,10 @@ export class ViewCompiler {
             if (info.command && (info.command !== 'options') && type.primaryProperty) {
               let primaryProperty = type.primaryProperty;
               attrName = info.attrName = primaryProperty.name;
-              // note that the defaultBindingMode always overrides the attribute bindingMode which is only used for "single-value" custom attributes 
+              // note that the defaultBindingMode always overrides the attribute bindingMode which is only used for "single-value" custom attributes
               // when using the syntax `<div square.bind="color"></div>`
               info.defaultBindingMode = primaryProperty.defaultBindingMode;
-          }
+            }
           }
         }
       } else if (elementInstruction) { //or if this is on a custom element

--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -205,7 +205,11 @@ export class ViewCompiler {
             // associate the attribute value with the name of the default bindable property
             // (otherwise it will remain associated with "value")
             if (info.command && (info.command !== 'options') && type.primaryProperty) {
-              attrName = info.attrName = type.primaryProperty.name;
+              let primaryProperty = type.primaryProperty;
+              attrName = info.attrName = primaryProperty.name;
+              // note that the defaultBindingMode always overrides the attribute bindingMode which is only used for "single-value" custom attributes 
+              // when using the syntax `<div square.bind="color"></div>`
+              info.defaultBindingMode = primaryProperty.defaultBindingMode;
             }
           }
         }


### PR DESCRIPTION
This is a bug fix for [#56](https://github.com/aurelia/templating-binding/issues/56)

[#391](https://github.com/aurelia/validation/issues/391) depends on this bug fix.  It requires two-way binding to work in the case when we're binding using the `primaryProperty` syntax.

