### PR TITLE
feat(templating-engine): Register View with container on enhance

### DIFF
--- a/src/templating-engine.js
+++ b/src/templating-engine.js
@@ -3,6 +3,7 @@ import {DOM} from 'aurelia-pal';
 import {Controller} from './controller';
 import {ModuleAnalyzer} from './module-analyzer';
 import {Animator} from './animator';
+import {View} from './view';
 import {ViewResources} from './view-resources';
 import {CompositionEngine} from './composition-engine';
 import {ViewFactory} from './view-factory';
@@ -95,6 +96,7 @@ export class TemplatingEngine {
     let view = factory.create(container, BehaviorInstruction.enhance());
 
     view.bind(instruction.bindingContext || {}, instruction.overrideContext);
+    container.registerInstance(View, view);
 
     return view;
   }

--- a/test/templating-engine.spec.js
+++ b/test/templating-engine.spec.js
@@ -3,6 +3,7 @@ import {Container} from 'aurelia-dependency-injection';
 import {createOverrideContext} from 'aurelia-binding';
 import {TemplatingEngine} from '../src/templating-engine';
 import {ViewResources} from '../src/view-resources';
+import {View} from '../src/view';
 import {DOM} from 'aurelia-pal';
 
 describe('enhance', () => {
@@ -45,5 +46,14 @@ describe('enhance', () => {
     let r = compileNodeSpy.calls.argsFor(0)[1];
 
     expect(r).toBe(resources);
+  });
+
+  it('registers the enhanced View with the container from the EnhanceInstruction', () => {
+    let view = templatingEngine.enhance({
+      container: container,
+      element: element
+    });
+
+    expect(view).toBe(container.get(View));
   });
 });


### PR DESCRIPTION
It took some verbose code to try to access a View from within an enhanced component. This change registers the View instance on the relevant container when calling enhance.

closes #516