### PR TITLE
feat(aliases): aliases for custom attributes

### DIFF
--- a/src/decorators.js
+++ b/src/decorators.js
@@ -57,8 +57,12 @@ export function customElement(name: string): any {
 * @param name The name of the custom attribute.
 * @param defaultBindingMode The default binding mode to use when the attribute is bound wtih .bind.
 */
-export function customAttribute(name: string, defaultBindingMode?: number): any {
+export function customAttribute(name: string, defaultBindingMode?: number, aliases?: string[]): any {
   return function(target) {
+    if (aliases) {
+      target.aliases = aliases;
+    }
+
     let r = metadata.getOrCreateOwn(metadata.resource, HtmlBehaviorResource, target);
     r.attributeName = validateBehaviorName(name, 'custom attribute');
     r.attributeDefaultBindingMode = defaultBindingMode;

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -55,7 +55,8 @@ export function customElement(name: string): any {
 /**
 * Decorator: Indicates that the decorated class is a custom attribute.
 * @param name The name of the custom attribute.
-* @param defaultBindingMode The default binding mode to use when the attribute is bound wtih .bind.
+* @param defaultBindingMode The default binding mode to use when the attribute is bound with .bind.
+* @param aliases The array of aliases to associate to the custom attribute.
 */
 export function customAttribute(name: string, defaultBindingMode?: number, aliases?: string[]): any {
   return function(target) {

--- a/src/decorators.js
+++ b/src/decorators.js
@@ -60,13 +60,10 @@ export function customElement(name: string): any {
 */
 export function customAttribute(name: string, defaultBindingMode?: number, aliases?: string[]): any {
   return function(target) {
-    if (aliases) {
-      target.aliases = aliases;
-    }
-
     let r = metadata.getOrCreateOwn(metadata.resource, HtmlBehaviorResource, target);
     r.attributeName = validateBehaviorName(name, 'custom attribute');
     r.attributeDefaultBindingMode = defaultBindingMode;
+    r.aliases = aliases;
   };
 }
 

--- a/src/html-behavior.js
+++ b/src/html-behavior.js
@@ -168,6 +168,12 @@ export class HtmlBehaviorResource {
   register(registry: ViewResources, name?: string): void {
     if (this.attributeName !== null) {
       registry.registerAttribute(name || this.attributeName, this, this.attributeName);
+
+      if (Array.isArray(this.target.aliases)) {
+        this.target.aliases.forEach( (alias) => {
+          registry.registerAttribute(alias, this, this.attributeName);
+        });
+      }
     }
 
     if (this.elementName !== null) {

--- a/src/html-behavior.js
+++ b/src/html-behavior.js
@@ -170,9 +170,16 @@ export class HtmlBehaviorResource {
       registry.registerAttribute(name || this.attributeName, this, this.attributeName);
 
       if (Array.isArray(this.target.aliases)) {
-        this.target.aliases.forEach( (alias) => {
-          registry.registerAttribute(alias, this, this.attributeName);
-        });
+        this.target
+          .aliases
+          .filter((a, pos, arr) =>
+             a !== this.attributeName &&
+             typeof a === 'string' &&
+             a.length > 0 &&
+             arr.indexOf(a) === pos)
+          .forEach( (alias) => {
+            registry.registerAttribute(alias, this, this.attributeName);
+          });
       }
     }
 

--- a/src/html-behavior.js
+++ b/src/html-behavior.js
@@ -171,11 +171,6 @@ export class HtmlBehaviorResource {
 
       if (Array.isArray(this.aliases)) {
         this.aliases
-          .filter((a, pos, arr) =>
-             a !== this.attributeName &&
-             typeof a === 'string' &&
-             a.length > 0 &&
-             arr.indexOf(a) === pos)
           .forEach( (alias) => {
             registry.registerAttribute(alias, this, this.attributeName);
           });

--- a/src/html-behavior.js
+++ b/src/html-behavior.js
@@ -169,9 +169,8 @@ export class HtmlBehaviorResource {
     if (this.attributeName !== null) {
       registry.registerAttribute(name || this.attributeName, this, this.attributeName);
 
-      if (Array.isArray(this.target.aliases)) {
-        this.target
-          .aliases
+      if (Array.isArray(this.aliases)) {
+        this.aliases
           .filter((a, pos, arr) =>
              a !== this.attributeName &&
              typeof a === 'string' &&

--- a/src/module-analyzer.js
+++ b/src/module-analyzer.js
@@ -79,7 +79,14 @@ export class ResourceModule {
           resource.metadata.attributeName !== undefined &&
           resource.value &&
           Array.isArray(resource.value.aliases)) {
-        resource.value.aliases.forEach( (alias) => {
+        resource.value
+          .aliases
+          .filter((a, pos, arr) =>
+            a !== resource.metadata.attributeName &&
+            typeof a === "string" &&
+            a.length > 0 &&
+            arr.indexOf(a) === pos)
+          .forEach( (alias) => {
           registry.registerAttribute(alias, resource.metadata, resource.metadata.attributeName);
         });
       }

--- a/src/module-analyzer.js
+++ b/src/module-analyzer.js
@@ -70,26 +70,8 @@ export class ResourceModule {
     }
 
     for (let i = 0, ii = resources.length; i < ii; ++i) {
-      const resource = resources[i];
-      resource.register(registry, name);
+      resources[i].register(registry, name);
       name = null;
-
-      /* register any aliases present */
-      if (resource.metadata &&
-          resource.metadata.attributeName !== undefined &&
-          resource.value &&
-          Array.isArray(resource.value.aliases)) {
-        resource.value
-          .aliases
-          .filter((a, pos, arr) =>
-            a !== resource.metadata.attributeName &&
-            typeof a === "string" &&
-            a.length > 0 &&
-            arr.indexOf(a) === pos)
-          .forEach( (alias) => {
-          registry.registerAttribute(alias, resource.metadata, resource.metadata.attributeName);
-        });
-      }
     }
   }
 

--- a/src/module-analyzer.js
+++ b/src/module-analyzer.js
@@ -70,8 +70,19 @@ export class ResourceModule {
     }
 
     for (let i = 0, ii = resources.length; i < ii; ++i) {
-      resources[i].register(registry, name);
+      const resource = resources[i];
+      resource.register(registry, name);
       name = null;
+
+      /* register any aliases present */
+      if (resource.metadata &&
+          resource.metadata.attributeName !== undefined &&
+          resource.value &&
+          Array.isArray(resource.value.aliases)) {
+        resource.value.aliases.forEach( (alias) => {
+          registry.registerAttribute(alias, resource.metadata, resource.metadata.attributeName);
+        });
+      }
     }
   }
 

--- a/test/html-behavior.spec.js
+++ b/test/html-behavior.spec.js
@@ -5,7 +5,7 @@ import {TaskQueue} from 'aurelia-task-queue';
 import {HtmlBehaviorResource} from '../src/html-behavior';
 import {ViewResources} from '../src/view-resources';
 
-fdescribe('html-behavior', () => {
+describe('html-behavior', () => {
   let defaultBindingMode = bindingMode.oneWay;
 
   it('should leave BindableProperty defaultBindingMode undefined after initialize when unspecified', () => {

--- a/test/html-behavior.spec.js
+++ b/test/html-behavior.spec.js
@@ -29,9 +29,9 @@ describe('html-behavior', () => {
 
     const resource = new HtmlBehaviorResource();
     resource.attributeName = 'test';
+    resource.aliases = ['foo', 'bar', 'test'];
 
     let target = function() {};
-    target.aliases = ['foo', 'bar', 'test'];
 
     let container = new Container();
     container.registerInstance(ObserverLocator, {});

--- a/test/html-behavior.spec.js
+++ b/test/html-behavior.spec.js
@@ -29,7 +29,7 @@ describe('html-behavior', () => {
 
     const resource = new HtmlBehaviorResource();
     resource.attributeName = 'test';
-    resource.aliases = ['foo', 'bar', 'test'];
+    resource.aliases = ['foo', 'bar'];
 
     let target = function() {};
 
@@ -39,7 +39,7 @@ describe('html-behavior', () => {
     resource.initialize(container, target);
     resource.register(resources);
 
-    // alias test should be skipped as it is the original name
+    // one call for the base name and 2 for the aliases
     expect(resources.registerAttribute).toHaveBeenCalledTimes(3);
   });
 

--- a/test/html-behavior.spec.js
+++ b/test/html-behavior.spec.js
@@ -31,7 +31,7 @@ fdescribe('html-behavior', () => {
     resource.attributeName = 'test';
 
     let target = function() {};
-    target.aliases = ['foo', 'bar'];
+    target.aliases = ['foo', 'bar', 'test'];
 
     let container = new Container();
     container.registerInstance(ObserverLocator, {});
@@ -39,6 +39,7 @@ fdescribe('html-behavior', () => {
     resource.initialize(container, target);
     resource.register(resources);
 
+    // alias test should be skipped as it is the original name
     expect(resources.registerAttribute).toHaveBeenCalledTimes(3);
   });
 

--- a/test/html-behavior.spec.js
+++ b/test/html-behavior.spec.js
@@ -3,35 +3,55 @@ import {Container} from 'aurelia-dependency-injection';
 import {ObserverLocator, bindingMode} from 'aurelia-binding';
 import {TaskQueue} from 'aurelia-task-queue';
 import {HtmlBehaviorResource} from '../src/html-behavior';
+import {ViewResources} from '../src/view-resources';
 
-describe('html-behavior', () => {
-  var defaultBindingMode = bindingMode.oneWay;
+fdescribe('html-behavior', () => {
+  let defaultBindingMode = bindingMode.oneWay;
 
   it('should leave BindableProperty defaultBindingMode undefined after initialize when unspecified', () => {
-    var resource = new HtmlBehaviorResource();
+    let resource = new HtmlBehaviorResource();
     resource.attributeName = 'test';
 
-    var container = new Container();
+    let container = new Container();
     container.registerInstance(ObserverLocator, {});
     container.registerInstance(TaskQueue, {});
 
-    var target = function() {};
+    let target = function() {};
 
     resource.initialize(container, target);
 
     expect(resource.attributes['test'].defaultBindingMode).toBe(defaultBindingMode);
   });
 
+  it('should register aliases for a custom attribute if provided', () => {
+    const resources = new ViewResources(new ViewResources(), 'app.html');
+    spyOn(resources, 'registerAttribute').and.callThrough();
+
+    const resource = new HtmlBehaviorResource();
+    resource.attributeName = 'test';
+
+    let target = function() {};
+    target.aliases = ['foo', 'bar'];
+
+    let container = new Container();
+    container.registerInstance(ObserverLocator, {});
+    container.registerInstance(TaskQueue, {});
+    resource.initialize(container, target);
+    resource.register(resources);
+
+    expect(resources.registerAttribute).toHaveBeenCalledTimes(3);
+  });
+
   it('should leave set BindableProperty defaultBindingMode after initialize when specified', () => {
-    var resource = new HtmlBehaviorResource();
+    let resource = new HtmlBehaviorResource();
     resource.attributeName = 'test';
     resource.attributeDefaultBindingMode = bindingMode.twoWay;
 
-    var container = new Container();
+    let container = new Container();
     container.registerInstance(ObserverLocator, {});
     container.registerInstance(TaskQueue, {});
 
-    var target = function() {};
+    let target = function() {};
 
     resource.initialize(container, target);
 


### PR DESCRIPTION
Allows to create aliases for custom attributes by providing an array of aliases to the customAttribute decorator, or by applying then on the targets static property aliases