### PR TITLE
fix(primaryProperty): infinite recursion with template controller

### DIFF
--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -293,6 +293,7 @@ export class ViewCompiler {
     let attr;
     let attrName;
     let attrValue;
+    let originalAttrName;
     let instruction;
     let info;
     let property;
@@ -319,7 +320,7 @@ export class ViewCompiler {
 
     for (i = 0, ii = attributes.length; i < ii; ++i) {
       attr = attributes[i];
-      attrName = attr.name;
+      originalAttrName = attrName = attr.name;
       attrValue = attr.value;
       info = bindingLanguage.inspectAttribute(resources, tagName, attrName, attrValue);
 
@@ -380,7 +381,7 @@ export class ViewCompiler {
             this._configureProperties(instruction, resources);
 
             if (type.liftsContent) { //template controller
-              instruction.originalAttrName = attrName;
+              instruction.originalAttrName = originalAttrName;
               liftingInstruction = instruction;
               break;
             } else { //attached behavior
@@ -398,7 +399,7 @@ export class ViewCompiler {
           instruction.attributes[resources.mapAttribute(attrName)] = attrValue;
 
           if (type.liftsContent) { //template controller
-            instruction.originalAttrName = attrName;
+            instruction.originalAttrName = originalAttrName;
             liftingInstruction = instruction;
             break;
           } else { //attached behavior


### PR DESCRIPTION
Using `primaryProperty` on a `templateController` attribute results in infinite recursion.

The reason is that `instruction.originalAttrName` sole purpose is to be removed from the template but because `primaryProperty` override `attrName` with the option name, it doesn't remove the attribute from the template anymore, hence the loop.

I fixed this specific bug only.

**There are other usages of `attrName` in `view-compiler` and I find _highly suspicious_ that we should replace the real custom attribute name with one of its options property. This wouldn't happen when not using `primaryProperty` so smells very wrong to me. Someone with more templating knowledge than me should review these uses.**

If I'm correct about this being unwanted, another fix could be to not re-assign `attrName` rather than introducing an extra `originalAttrName` variable like I did.

CC: @dkent600 introduced this change.