### PR TITLE
Typo in Typescript example?

### DIFF
--- a/doc/article/en-US/templating-custom-attributes.md
+++ b/doc/article/en-US/templating-custom-attributes.md
@@ -258,7 +258,7 @@ With options bindings each bindable property must be decorated with the `bindabl
     @autoinject
     export class SquareCustomAttribute {
       @bindable sideLength: string;
-      @bindable color({ primaryProperty: true }): string;
+      @bindable({ primaryProperty: true }) color: string;
 
       constructor(private element: Element){
       }


### PR DESCRIPTION
I'm pretty sure the typescript example was wrong...