### PR TITLE
docs) fixes issue in example for using compose

### DIFF
--- a/doc/article/en-US/templating-basics.md
+++ b/doc/article/en-US/templating-basics.md
@@ -220,7 +220,7 @@ an HTML template, a view-model, and maybe even some initialization data for us? 
   <source-code lang="HTML">
     <template>
       <compose view-model="hello"
-               view.bind="hello.html"
+               view="hello.html"
                model.bind="{ target : 'World' }" ></compose>
     </template>
   </source-code>

--- a/doc/article/en-US/templating-basics.md
+++ b/doc/article/en-US/templating-basics.md
@@ -220,7 +220,7 @@ an HTML template, a view-model, and maybe even some initialization data for us? 
   <source-code lang="HTML">
     <template>
       <compose view-model="hello"
-               view="hello.html"
+               view="./hello.html"
                model.bind="{ target : 'World' }" ></compose>
     </template>
   </source-code>


### PR DESCRIPTION
The docs suggest that the compose element component should supply a view attribute and bind a path to a html file. The example is working, but it is very error prone.

This works as expected:
```<compose view-model="hello" view.bind="hello.html"></compose>```

But when the view is being retrieved from a different directory, it starts to give errors:
```<compose view-model="hello" view.bind="../hello.html"></compose>```

Gives an error like:
```ERROR [app-router] Error: Parser Error: Unexpected token . at column 1 in [xxx.html]```

The fix to this issue is to either remove the `.bind`:
```<compose view-model="hello" view="../hello.html"></compose>```

or add single quotes:
```<compose view-model="hello" view.bind="'../hello.html'"></compose>```

Edit: I could also explain this issue in the docs if needed. Let me know and I'd be happy to prettify above explanation so that it can be used in the docs.