### PR TITLE
Fix typo in the dynamicOptions example: value -> newValue

### DIFF
--- a/doc/article/en-US/templating-custom-attributes.md
+++ b/doc/article/en-US/templating-custom-attributes.md
@@ -314,7 +314,7 @@ Utilizing dynamic options, a custom attribute may deal with bindable properties 
             this.element.style.width = this.element.style.height = `${newValue}px`;
             break;
           default:
-            this.element.style[name] = value;
+            this.element.style[name] = newValue;
             break;
         }
       }


### PR DESCRIPTION
This fixes a typo in the custom attribute dynamic options documentation. The variable used in the last clause of the `switch` should be `newValue`