### PR TITLE
fix(view-engine): use .address in case of RegistryEntry

### DIFF
--- a/src/view-engine.js
+++ b/src/view-engine.js
@@ -102,9 +102,10 @@ export class ViewEngine {
     loadContext = loadContext || new ResourceLoadContext();
 
     return ensureRegistryEntry(this.loader, urlOrRegistryEntry).then(registryEntry => {
+      const url = typeof urlOrRegistryEntry === 'string' ? urlOrRegistryEntry : urlOrRegistryEntry.address;
       if (registryEntry.onReady) {
-        if (!loadContext.hasDependency(urlOrRegistryEntry)) {
-          loadContext.addDependency(urlOrRegistryEntry);
+        if (!loadContext.hasDependency(url)) {
+          loadContext.addDependency(url);
           return registryEntry.onReady;
         }
 
@@ -116,7 +117,7 @@ export class ViewEngine {
         return Promise.resolve(new ProxyViewFactory(registryEntry.onReady));
       }
 
-      loadContext.addDependency(urlOrRegistryEntry);
+      loadContext.addDependency(url);
 
       registryEntry.onReady = this.loadTemplateResources(registryEntry, compileInstruction, loadContext, target).then(resources => {
         registryEntry.resources = resources;


### PR DESCRIPTION
When `urlOrRegistryEntry` is of type `RegistryEntry` we end up with `[object Object]` as a key in the `loadContext.dependencies` after calling `loadContext.addDependency`.
@EisenbergEffect *Not sure* if using `urlOrRegistryEntry.address` is the correct fix. I found this accidentally while familiarizing myself with templating.