### PR TITLE
feat(BindableProperty): Reflect prop to attribute

### DIFF
--- a/src/bindable-property.js
+++ b/src/bindable-property.js
@@ -35,7 +35,13 @@ export class BindableProperty {
   * Creates an instance of BindableProperty.
   * @param nameOrConfig The name of the property or a cofiguration object.
   */
-  constructor(nameOrConfig) {
+  constructor(nameOrConfig: string | {
+    defaultBindingMode?: number,
+    reflect?: boolean | {(el: Element, newVal, oldVal): any},
+    name?: string,
+    attribute?: any,
+    changeHandler?: string
+  }) {
     if (typeof nameOrConfig === 'string') {
       this.name = nameOrConfig;
     } else {

--- a/src/bindable-property.js
+++ b/src/bindable-property.js
@@ -37,7 +37,7 @@ export class BindableProperty {
   */
   constructor(nameOrConfig: string | {
     defaultBindingMode?: number,
-    reflect?: boolean | {(el: Element, newVal, oldVal): any},
+    reflect?: boolean | {(el: Element, name: string, newVal, oldVal): any},
     name?: string,
     attribute?: any,
     changeHandler?: string

--- a/src/bindable-property.js
+++ b/src/bindable-property.js
@@ -35,7 +35,7 @@ export class BindableProperty {
   * Creates an instance of BindableProperty.
   * @param nameOrConfig The name of the property or a cofiguration object.
   */
-  constructor(nameOrConfig: string | Object) {
+  constructor(nameOrConfig) {
     if (typeof nameOrConfig === 'string') {
       this.name = nameOrConfig;
     } else {
@@ -61,6 +61,10 @@ export class BindableProperty {
     behavior.properties.push(this);
     behavior.attributes[this.attribute] = this;
     this.owner = behavior;
+
+    if (this.reflect) {
+      behavior.registerReflection(this.name, this.reflect);
+    }
 
     if (descriptor) {
       this.descriptor = descriptor;

--- a/src/html-behavior.js
+++ b/src/html-behavior.js
@@ -510,5 +510,9 @@ export class HtmlBehaviorResource {
  * @param {any} newValue 
  */
 function propToAttr(element, propertyName, newValue) {
-  element.setAttribute(propertyName, newValue);
+  if (newVal == null) {
+    element.removeAttribute(propertyName)
+  } else {
+    element.setAttribute(propertyName, newValue);
+  }
 }

--- a/src/html-behavior.js
+++ b/src/html-behavior.js
@@ -425,6 +425,7 @@ export class HtmlBehaviorResource {
    */
   _setupReflections(element, target) {
     if (!this.reflections) return;
+    if (this._reflectedTarget === target) return;
 
     let {reflections} = this;
     let method = 'propertyChanged';
@@ -446,6 +447,7 @@ export class HtmlBehaviorResource {
     })) {
       throw new Error(`Cannot setup property reflection on <${this.elementName}/> for ${target.name}`);
     };
+    this._reflectedTarget = target;
   }
 
   _ensurePropertiesDefined(instance: Object, lookup: Object) {

--- a/src/html-behavior.js
+++ b/src/html-behavior.js
@@ -512,7 +512,7 @@ export class HtmlBehaviorResource {
  * @param {any} newValue 
  */
 function propToAttr(element, propertyName, newValue) {
-  if (newVal == null) {
+  if (newValue == null) {
     element.removeAttribute(propertyName)
   } else {
     element.setAttribute(propertyName, newValue);

--- a/src/html-behavior.js
+++ b/src/html-behavior.js
@@ -405,7 +405,7 @@ export class HtmlBehaviorResource {
   /**
    * Allow a bindable property on custom element to register how to reflect prop value to attribute
    * @param {string} propertyName 
-   * @param {boolean | {(element: Element, newVal: any, oldVal: any) => any}} reflection 
+   * @param {boolean | {(element: Element, name: string, newVal, oldVal) => any}} reflection 
    */
   registerReflection(propertyName, reflection) {
     let reflections = this.reflections || (this.reflections = {});

--- a/src/view-factory.js
+++ b/src/view-factory.js
@@ -104,6 +104,10 @@ function setAttribute(name, value) {
   this._element.setAttribute(name, value);
 }
 
+function removeAttribute(name) {
+  this._element.removeAttribute(name);
+}
+
 function makeElementIntoAnchor(element, elementInstruction) {
   let anchor = DOM.createComment('anchor');
 
@@ -119,6 +123,7 @@ function makeElementIntoAnchor(element, elementInstruction) {
     anchor.hasAttribute = hasAttribute;
     anchor.getAttribute = getAttribute;
     anchor.setAttribute = setAttribute;
+    anchor.removeAttribute = removeAttribute;
   }
 
   DOM.replaceNode(anchor, element);

--- a/test/html-behavior.spec.js
+++ b/test/html-behavior.spec.js
@@ -3,6 +3,7 @@ import {Container} from 'aurelia-dependency-injection';
 import {ObserverLocator, bindingMode} from 'aurelia-binding';
 import {TaskQueue} from 'aurelia-task-queue';
 import {HtmlBehaviorResource} from '../src/html-behavior';
+import {BindableProperty} from '../src/bindable-property';
 import {ViewResources} from '../src/view-resources';
 
 describe('html-behavior', () => {
@@ -57,5 +58,27 @@ describe('html-behavior', () => {
     resource.initialize(container, target);
 
     expect(resource.attributes['test'].defaultBindingMode).toBe(bindingMode.twoWay);
+  });
+
+  describe('Prop to attribute reflection', () => {
+    it('should have reflections when bindable properties are registered with `reflect`', () => {
+      let resource = new HtmlBehaviorResource();
+      let Target = class {};
+
+      var prop1 = new BindableProperty({
+        reflect: true,
+        name: 'prop1'
+      });
+      prop1.registerWith(Target, resource);
+
+      var prop2 = new BindableProperty({
+        reflect() {},
+        name: 'prop2'
+      });
+      prop2.registerWith(Target, resource);
+
+      expect(typeof resource.reflections.prop1).toBe('function');
+      expect(resource.reflections.prop2).toBe(prop2.reflect);
+    });
   });
 });


### PR DESCRIPTION
This PR addresses: aurelia/binding#347 @AshleyGrant 

Note:

* It doesn't support app root component
* It doesn't support compose element
* It still set the attribute on `containerless` element
* It only has setup test so far
* [Demo](https://gist.run/?id=995e1c6a5e1ccecdec46f8421f862b72)

**Usage with `bindable` decorator:

```js
class MyComponent {
  @bindable({
    reflect: true // This instruct it to map prop -> attr 1:1
  })
  prop1

  @bindable({
    // Alternatively can be passed a function as instruction how to reflect the property to the element
    reflect(element: Element, propertyName: string, newVal, oldVal) {
      element.setAttribute(propertyName, `${oldVal} -- ${newVal}`);
    }
  })
  prop2
}
```

cc @EisenbergEffect @jdanyow 
