### PR TITLE
feat(Let): let element for computed property declaration

### DIFF
--- a/dist/aurelia-templating.d.ts
+++ b/dist/aurelia-templating.d.ts
@@ -22,6 +22,7 @@ import {
   inject
 } from 'aurelia-dependency-injection';
 import {
+  Scope,
   ValueConverterResource,
   BindingBehaviorResource,
   camelCase,
@@ -47,12 +48,12 @@ export declare interface EventHandler {
 * Specifies how a view should be created.
 */
 export declare interface ViewCreateInstruction {
-  
+
   /**
     * Indicates that the view is being created by enhancing existing DOM.
     */
   enhance?: boolean;
-  
+
   /**
     * Specifies a key/value lookup of part replacements for the view being created.
     */
@@ -63,7 +64,7 @@ export declare interface ViewCreateInstruction {
 * Implemented by classes that describe how a view factory should be loaded.
 */
 export declare interface ViewStrategy {
-  
+
   /**
     * Loads a view factory.
     * @param viewEngine The view engine to use during the load process.
@@ -83,7 +84,7 @@ export declare interface IStaticViewConfig {
 * View engine hooks that enable a view resource to provide custom processing during the compilation or creation of a view.
 */
 export declare interface ViewEngineHooks {
-  
+
   /**
     * Invoked before a template is compiled.
     * @param content The DocumentFragment to compile.
@@ -91,13 +92,13 @@ export declare interface ViewEngineHooks {
     * @param instruction The compilation instruction associated with the compilation process.
     */
   beforeCompile?: (content: DocumentFragment, resources: ViewResources, instruction: ViewCompileInstruction) => void;
-  
+
   /**
     * Invoked after a template is compiled.
     * @param viewFactory The view factory that was produced from the compilation process.
     */
   afterCompile?: (viewFactory: ViewFactory) => void;
-  
+
   /**
     * Invoked before a view is created.
     * @param viewFactory The view factory that will be used to create the view.
@@ -106,19 +107,19 @@ export declare interface ViewEngineHooks {
     * @param instruction The view creation instruction associated with this creation process.
     */
   beforeCreate?: (viewFactory: ViewFactory, container: Container, content: DocumentFragment, instruction: ViewCreateInstruction) => void;
-  
+
   /**
     * Invoked after a view is created.
     * @param view The view that was created by the factory.
     */
   afterCreate?: (view: View) => void;
-  
+
   /**
     * Invoked after the bindingContext and overrideContext are configured on the view but before the view is bound.
     * @param view The view that was created by the factory.
     */
   beforeBind?: (view: View) => void;
-  
+
   /**
     * Invoked before the view is unbind. The bindingContext and overrideContext are still available on the view.
     * @param view The view that was created by the factory.
@@ -126,83 +127,83 @@ export declare interface ViewEngineHooks {
   beforeUnbind?: (view: View) => void;
 }
 export declare interface IBindablePropertyConfig {
-  
+
   /**
     * The name of the property.
     */
   name?: string;
   attribute?: string;
-  
+
   /**
      * The default binding mode of the property. If given string, will use to lookup
      */
   defaultBindingMode?: bindingMode | 'oneTime' | 'oneWay' | 'twoWay' | 'fromView' | 'toView';
-  
+
   /**
      * The name of a view model method to invoke when the property is updated.
      */
   changeHandler?: string;
-  
+
   /**
      * A default value for the property.
      */
   defaultValue?: any;
-  
+
   /**
      * Designates the property as the default bindable property among all the other bindable properties when used in a custom attribute with multiple bindable properties.
      */
   primaryProperty?: boolean;
-  
+
   // For compatibility and future extension
   [key: string]: any;
 }
 export declare interface IStaticResourceConfig {
-  
+
   /**
      * Resource type of this class, omit equals to custom element
      */
   type?: 'element' | 'attribute' | 'valueConverter' | 'bindingBehavior' | 'viewEngineHooks';
-  
+
   /**
      * Name of this resource. Reccommended to explicitly set to works better with minifier
      */
   name?: string;
-  
+
   /**
      * Used to tell if a custom attribute is a template controller
      */
   templateController?: boolean;
-  
+
   /**
      * Used to set default binding mode of default custom attribute view model "value" property
      */
   defaultBindingMode?: bindingMode | 'oneTime' | 'oneWay' | 'twoWay' | 'fromView' | 'toView';
-  
+
   /**
      * Flags a custom attribute has dynamic options
      */
   hasDynamicOptions?: boolean;
-  
+
   /**
      * Flag if this custom element uses native shadow dom instead of emulation
      */
   usesShadowDOM?: boolean;
-  
+
   /**
      * Options that will be used if the element is flagged with usesShadowDOM
      */
   shadowDOMOptions?: ShadowRootInit;
-  
+
   /**
      * Flag a custom element as containerless. Which will remove their render target
      */
   containerless?: boolean;
-  
+
   /**
      * Custom processing of the attributes on an element before the framework inspects them.
      */
   processAttributes?: (viewCompiler: ViewCompiler, resources: ViewResources, node: Element, attributes: NamedNodeMap, elementInstruction: BehaviorInstruction) => void;
-  
+
   /**
      * Enables custom processing of the content that is places inside the custom element by its consumer.
      * Pass a boolean to direct the template compiler to not process
@@ -211,7 +212,7 @@ export declare interface IStaticResourceConfig {
      * a boolean indicating whether the compiler should also process the content.
      */
   processContent?: (viewCompiler: ViewCompiler, resources: ViewResources, node: Element, instruction: BehaviorInstruction) => boolean;
-  
+
   /**
      * List of bindable properties of this custom element / custom attribute, by name or full config object
      */
@@ -223,24 +224,24 @@ export declare interface IStaticResourceConfig {
 * Represents a node in the view hierarchy.
 */
 export declare interface ViewNode {
-  
+
   /**
     * Binds the node and it's children.
     * @param bindingContext The binding context to bind to.
     * @param overrideContext A secondary binding context that can override the standard context.
     */
   bind(bindingContext: Object, overrideContext?: Object): void;
-  
+
   /**
     * Triggers the attach for the node and its children.
     */
   attached(): void;
-  
+
   /**
     * Triggers the detach for the node and its children.
     */
   detached(): void;
-  
+
   /**
     * Unbinds the node and its children.
     */
@@ -251,7 +252,7 @@ export declare interface ViewNode {
 * An optional interface describing the created convention.
 */
 export declare interface ComponentCreated {
-  
+
   /**
       * Implement this hook if you want to perform custom logic after the constructor has been called.
       * At this point in time, the view has also been created and both the view-model and the view
@@ -269,7 +270,7 @@ export declare interface ComponentCreated {
 * An optional interface describing the bind convention.
 */
 export declare interface ComponentBind {
-  
+
   /**
       * Implement this hook if you want to perform custom logic when databinding is activated on the view and view-model.
       * The "binding context" to which the component is being bound will be passed first.
@@ -286,7 +287,7 @@ export declare interface ComponentBind {
 * An optional interface describing the attached convention.
 */
 export declare interface ComponentAttached {
-  
+
   /**
       * Implement this hook if you want to perform custom logic when the component is attached to the DOM (in document).
       */
@@ -300,7 +301,7 @@ export declare interface ComponentAttached {
 * An optional interface describing the detached convention.
 */
 export declare interface ComponentDetached {
-  
+
   /**
       * Implement this hook if you want to perform custom logic if/when the component is removed from the the DOM.
       */
@@ -314,7 +315,7 @@ export declare interface ComponentDetached {
 * An optional interface describing the unbind convention.
 */
 export declare interface ComponentUnbind {
-  
+
   /**
       * Implement this hook if you want to perform custom logic after the component is detached and unbound.
       */
@@ -328,7 +329,7 @@ export declare interface ComponentUnbind {
 * An optional interface describing the getViewStrategy convention for dynamic components (used with the compose element or the router).
 */
 export declare interface DynamicComponentGetViewStrategy {
-  
+
   /**
       * Implement this hook if you want to provide custom view strategy when this component is used with the compose element or the router.
       */
@@ -339,67 +340,67 @@ export declare interface DynamicComponentGetViewStrategy {
 * Instructs the composition engine how to dynamically compose a component.
 */
 export declare interface CompositionContext {
-  
+
   /**
     * The parent Container for the component creation.
     */
   container: Container;
-  
+
   /**
     * The child Container for the component creation. One will be created from the parent if not provided.
     */
   childContainer?: Container;
-  
+
   /**
     * The context in which the view model is executed in.
     */
   bindingContext: any;
-  
+
   /**
     * A secondary binding context that can override the standard context.
     */
   overrideContext?: any;
-  
+
   /**
     * The view model url or instance for the component.
     */
   viewModel?: any;
-  
+
   /**
     * Data to be passed to the "activate" hook on the view model.
     */
   model?: any;
-  
+
   /**
     * The HtmlBehaviorResource for the component.
     */
   viewModelResource?: HtmlBehaviorResource;
-  
+
   /**
     * The view resources for the view in which the component should be created.
     */
   viewResources: ViewResources;
-  
+
   /**
     * The view inside which this composition is happening.
     */
   owningView?: View;
-  
+
   /**
     * The view url or view strategy to override the default view location convention.
     */
   view?: string | ViewStrategy;
-  
+
   /**
     * The slot to push the dynamically composed component into.
     */
   viewSlot: ViewSlot;
-  
+
   /**
     * Should the composition system skip calling the "activate" hook on the view model.
     */
   skipActivation?: boolean;
-  
+
   /**
     * The element that will parent the dynamic component.
     * It will be registered in the child container of this composition.
@@ -415,27 +416,27 @@ export declare interface IStaticViewStrategyConfig {
 * Instructs the framework in how to enhance an existing DOM structure.
 */
 export declare interface EnhanceInstruction {
-  
+
   /**
     * The DI container to use as the root for UI enhancement.
     */
   container?: Container;
-  
+
   /**
     * The element to enhance.
     */
   element: Element;
-  
+
   /**
     * The resources available for enhancement.
     */
   resources?: ViewResources;
-  
+
   /**
     * A binding context for the enhancement.
     */
   bindingContext?: Object;
-  
+
   /**
     * A secondary binding context that can override the standard context.
     */
@@ -451,21 +452,21 @@ export declare const animationEvent: any;
  * An abstract class representing a mechanism for animating the DOM during various DOM state transitions.
  */
 export declare class Animator {
-  
+
   /**
      * Execute an 'enter' animation on an element
      * @param element Element to animate
      * @returns Resolved when the animation is done
      */
   enter(element: HTMLElement): Promise<boolean>;
-  
+
   /**
      * Execute a 'leave' animation on an element
      * @param element Element to animate
      * @returns Resolved when the animation is done
      */
   leave(element: HTMLElement): Promise<boolean>;
-  
+
   /**
      * Add a class to an element to trigger an animation.
      * @param element Element to animate
@@ -473,7 +474,7 @@ export declare class Animator {
      * @returns Resolved when the animation is done
      */
   removeClass(element: HTMLElement, className: string): Promise<boolean>;
-  
+
   /**
      * Add a class to an element to trigger an animation.
      * @param element Element to animate
@@ -481,7 +482,7 @@ export declare class Animator {
      * @returns Resolved when the animation is done
      */
   addClass(element: HTMLElement, className: string): Promise<boolean>;
-  
+
   /**
      * Execute a single animation.
      * @param element Element to animate
@@ -490,7 +491,7 @@ export declare class Animator {
      * @returns Resolved when the animation is done
      */
   animate(element: HTMLElement | Array<HTMLElement>, className: string): Promise<boolean>;
-  
+
   /**
      * Run a sequence of animations one after the other.
      * for example: animator.runSequence("fadeIn","callout")
@@ -498,14 +499,14 @@ export declare class Animator {
      * @returns Resolved when all animations are done
      */
   runSequence(animations: Array<any>): Promise<boolean>;
-  
+
   /**
      * Register an effect (for JS based animators)
      * @param effectName identifier of the effect
      * @param properties Object with properties for the effect
      */
   registerEffect(effectName: string, properties: Object): void;
-  
+
   /**
      * Unregister an effect (for JS based animators)
      * @param effectName identifier of the effect
@@ -518,7 +519,7 @@ export declare class Animator {
 */
 export declare class CompositionTransactionNotifier {
   constructor(owner?: any);
-  
+
   /**
     * Notifies the owning transaction that its work is done.
     */
@@ -530,13 +531,13 @@ export declare class CompositionTransactionNotifier {
 */
 export declare class CompositionTransactionOwnershipToken {
   constructor(owner?: any);
-  
+
   /**
     * Allows the transaction owner to wait for the completion of all child compositions.
     * @return A promise that resolves when all child compositions are done.
     */
   waitForCompositionComplete(): Promise<void>;
-  
+
   /**
     * Used internall to resolve the composition complete promise.
     */
@@ -547,18 +548,18 @@ export declare class CompositionTransactionOwnershipToken {
 * Enables an initiator of a view composition to track any internal async rendering processes for completion.
 */
 export declare class CompositionTransaction {
-  
+
   /**
     * Creates an instance of CompositionTransaction.
     */
   constructor();
-  
+
   /**
     * Attempt to take ownership of the composition transaction.
     * @return An ownership token if successful, otherwise null.
     */
   tryCapture(): CompositionTransactionOwnershipToken;
-  
+
   /**
     * Enlist an async render operation into the transaction.
     * @return A completion notifier.
@@ -578,43 +579,39 @@ export declare function viewEngineHooks(target?: any): any;
  * Dispatches subscribets to and publishes events in the DOM.
  * @param element
  */
-/**
- * Dispatches subscribets to and publishes events in the DOM.
- * @param element
- */
 export declare class ElementEvents {
   constructor(element: EventTarget);
-  
+
   /**
-     * Dispatches an Event on the context element.
-     * @param eventName
-     * @param detail
-     * @param bubbles
-     * @param cancelable
-     */
+   * Dispatches an Event on the context element.
+   * @param eventName
+   * @param detail
+   * @param bubbles
+   * @param cancelable
+   */
   publish(eventName: string, detail?: Object, bubbles?: boolean, cancelable?: boolean): any;
-  
+
   /**
      * Adds and Event Listener on the context element.
      * @return Returns the eventHandler containing a dispose method
      */
   subscribe(eventName: string, handler: Function, captureOrOptions?: boolean): EventHandler;
-  
+
   /**
      * Adds an Event Listener on the context element, that will be disposed on the first trigger.
      * @return Returns the eventHandler containing a dispose method
      */
   subscribeOnce(eventName: string, handler: Function, captureOrOptions?: boolean): EventHandler;
-  
+
   /**
-     * Removes all events that are listening to the specified eventName.
-     * @param eventName
-     */
+   * Removes all events that are listening to the specified eventName.
+   * @param eventName
+   */
   dispose(eventName: string): void;
-  
+
   /**
-     * Removes all event handlers.
-     */
+   * Removes all event handlers.
+   */
   disposeAll(): any;
 }
 
@@ -623,18 +620,18 @@ export declare class ElementEvents {
 */
 export declare class ResourceLoadContext {
   dependencies: Object;
-  
+
   /**
     * Creates an instance of ResourceLoadContext.
     */
   constructor();
-  
+
   /**
     * Tracks a dependency that is being loaded.
     * @param url The url of the dependency.
     */
   addDependency(url: string): void;
-  
+
   /**
     * Checks if the current context includes a load of the specified url.
     * @return True if the url is being loaded in the context; false otherwise.
@@ -649,12 +646,12 @@ export declare class ViewCompileInstruction {
   targetShadowDOM: boolean;
   compileSurrogate: boolean;
   associatedModuleId: any;
-  
+
   /**
     * The normal configuration for view compilation.
     */
   static normal: ViewCompileInstruction;
-  
+
   /**
     * Creates an instance of ViewCompileInstruction.
     * @param targetShadowDOM Should the compilation target the Shadow DOM.
@@ -684,18 +681,18 @@ export declare class BehaviorInstruction {
   type: HtmlBehaviorResource;
   attrName: string;
   inheritBindingContext: boolean;
-  
+
   /**
     * A default behavior used in scenarios where explicit configuration isn't available.
     */
   static normal: BehaviorInstruction;
-  
+
   /**
     * Creates an instruction for element enhancement.
     * @return The created instruction.
     */
   static enhance(): BehaviorInstruction;
-  
+
   /**
     * Creates an instruction for unit testing.
     * @param type The HtmlBehaviorResource to create.
@@ -703,7 +700,7 @@ export declare class BehaviorInstruction {
     * @return The created instruction.
     */
   static unitTest(type: HtmlBehaviorResource, attributes: Object): BehaviorInstruction;
-  
+
   /**
     * Creates a custom element instruction.
     * @param node The node that represents the custom element.
@@ -711,7 +708,7 @@ export declare class BehaviorInstruction {
     * @return The created instruction.
     */
   static element(node: Node, type: HtmlBehaviorResource): BehaviorInstruction;
-  
+
   /**
     * Creates a custom attribute instruction.
     * @param attrName The name of the attribute.
@@ -719,7 +716,7 @@ export declare class BehaviorInstruction {
     * @return The created instruction.
     */
   static attribute(attrName: string, type?: HtmlBehaviorResource): BehaviorInstruction;
-  
+
   /**
     * Creates a dynamic component instruction.
     * @param host The element that will parent the dynamic component.
@@ -728,7 +725,7 @@ export declare class BehaviorInstruction {
     * @return The created instruction.
     */
   static dynamic(host: Element, viewModel: Object, viewFactory: ViewFactory): BehaviorInstruction;
-  
+
   /**
     * Creates an instance of BehaviorInstruction.
     */
@@ -753,26 +750,26 @@ export declare class TargetInstruction {
   elementInstruction: BehaviorInstruction;
   lifting: boolean;
   values: Object;
-  
+
   /**
     * An empty array used to represent a target with no binding expressions.
     */
   static noExpressions: any;
-  
+
   /**
     * Creates an instruction that represents a shadow dom slot.
     * @param parentInjectorId The id of the parent dependency injection container.
     * @return The created instruction.
     */
   static shadowSlot(parentInjectorId: number): TargetInstruction;
-  
+
   /**
     * Creates an instruction that represents a binding expression in the content of an element.
     * @param expression The binding expression.
     * @return The created instruction.
     */
   static contentExpression(expression?: any): TargetInstruction;
-  
+
   /**
     * Creates an instruction that represents content that was lifted out of the DOM and into a ViewFactory.
     * @param parentInjectorId The id of the parent dependency injection container.
@@ -780,7 +777,7 @@ export declare class TargetInstruction {
     * @return The created instruction.
     */
   static lifting(parentInjectorId: number, liftingInstruction: BehaviorInstruction): TargetInstruction;
-  
+
   /**
     * Creates an instruction that represents an element with behaviors and bindings.
     * @param injectorId The id of the dependency injection container.
@@ -792,7 +789,7 @@ export declare class TargetInstruction {
     * @return The created instruction.
     */
   static normal(injectorId: number, parentInjectorId: number, providers: Array<Function>, behaviorInstructions: Array<BehaviorInstruction>, expressions: Array<Object>, elementInstruction: BehaviorInstruction): TargetInstruction;
-  
+
   /**
     * Creates an instruction that represents the surrogate behaviors and bindings for an element.
     * @param providers The types which will provide behavior for this element.
@@ -802,7 +799,7 @@ export declare class TargetInstruction {
     * @return The created instruction.
     */
   static surrogate(providers: Array<Function>, behaviorInstructions: Array<BehaviorInstruction>, expressions: Array<Object>, values: Object): TargetInstruction;
-  
+
   /**
     * Creates an instance of TargetInstruction.
     */
@@ -821,13 +818,13 @@ export declare const viewStrategy: Function;
 * A view strategy that loads a view relative to its associated view-model.
 */
 export declare class RelativeViewStrategy {
-  
+
   /**
     * Creates an instance of RelativeViewStrategy.
     * @param path The relative path to the view.
     */
   constructor(path: string);
-  
+
   /**
     * Loads a view factory.
     * @param viewEngine The view engine to use during the load process.
@@ -837,7 +834,7 @@ export declare class RelativeViewStrategy {
     * @return A promise for the view factory that is produced by this strategy.
     */
   loadViewFactory(viewEngine: ViewEngine, compileInstruction: ViewCompileInstruction, loadContext?: ResourceLoadContext, target?: any): Promise<ViewFactory>;
-  
+
   /**
     * Makes the view loaded by this strategy relative to the provided file path.
     * @param file The path to load the view relative to.
@@ -849,14 +846,14 @@ export declare class RelativeViewStrategy {
 * A view strategy based on naming conventions.
 */
 export declare class ConventionalViewStrategy {
-  
+
   /**
     * Creates an instance of ConventionalViewStrategy.
     * @param viewLocator The view locator service for conventionally locating the view.
     * @param origin The origin of the view model to conventionally load the view for.
     */
   constructor(viewLocator: ViewLocator, origin: Origin);
-  
+
   /**
     * Loads a view factory.
     * @param viewEngine The view engine to use during the load process.
@@ -873,14 +870,14 @@ export declare class ConventionalViewStrategy {
 * Typically used when the component author wishes to take over fine-grained rendering control.
 */
 export declare class NoViewStrategy {
-  
+
   /**
     * Creates an instance of NoViewStrategy.
     * @param dependencies A list of view resource dependencies of this view.
     * @param dependencyBaseUrl The base url for the view dependencies.
     */
   constructor(dependencies?: Array<string | Function | Object>, dependencyBaseUrl?: string);
-  
+
   /**
     * Loads a view factory.
     * @param viewEngine The view engine to use during the load process.
@@ -896,14 +893,14 @@ export declare class NoViewStrategy {
 * A view strategy created directly from the template registry entry.
 */
 export declare class TemplateRegistryViewStrategy {
-  
+
   /**
     * Creates an instance of TemplateRegistryViewStrategy.
     * @param moduleId The associated moduleId of the view to be loaded.
     * @param entry The template registry entry used in loading the view factory.
     */
   constructor(moduleId: string, entry: TemplateRegistryEntry);
-  
+
   /**
     * Loads a view factory.
     * @param viewEngine The view engine to use during the load process.
@@ -919,7 +916,7 @@ export declare class TemplateRegistryViewStrategy {
 * A view strategy that allows the component author to inline the html for the view.
 */
 export declare class InlineViewStrategy {
-  
+
   /**
     * Creates an instance of InlineViewStrategy.
     * @param markup The markup for the view. Be sure to include the wrapping template tag.
@@ -927,7 +924,7 @@ export declare class InlineViewStrategy {
     * @param dependencyBaseUrl The base url for the view dependencies.
     */
   constructor(markup: string, dependencies?: Array<string | Function | Object>, dependencyBaseUrl?: string);
-  
+
   /**
     * Loads a view factory.
     * @param viewEngine The view engine to use during the load process.
@@ -939,16 +936,16 @@ export declare class InlineViewStrategy {
   loadViewFactory(viewEngine: ViewEngine, compileInstruction: ViewCompileInstruction, loadContext?: ResourceLoadContext, target?: any): Promise<ViewFactory>;
 }
 export declare class StaticViewStrategy {
-  
+
   /**@internal */
   template: string | HTMLTemplateElement;
-  
+
   /**@internal */
   dependencies: Function[] | (() => Array<Function | Promise<Function | Record<string, Function>>>);
   factoryIsReady: boolean;
   factory: ViewFactory;
   constructor(config: string | HTMLTemplateElement | IStaticViewConfig);
-  
+
   /**
     * Loads a view factory.
     * @param viewEngine The view engine to use during the load process.
@@ -964,19 +961,19 @@ export declare class StaticViewStrategy {
 * Locates a view for an object.
 */
 export declare class ViewLocator {
-  
+
   /**
     * The metadata key for storing/finding view strategies associated with an class/object.
     */
   static viewStrategyMetadataKey: any;
-  
+
   /**
     * Gets the view strategy for the value.
     * @param value The value to locate the view strategy for.
     * @return The located ViewStrategy instance.
     */
   getViewStrategy(value: any): ViewStrategy;
-  
+
   /**
     * Creates a fallback View Strategy. Used when unable to locate a configured strategy.
     * The default implementation returns and instance of ConventionalViewStrategy.
@@ -984,7 +981,7 @@ export declare class ViewLocator {
     * @return The fallback ViewStrategy.
     */
   createFallbackViewStrategy(origin: Origin): ViewStrategy;
-  
+
   /**
     * Conventionally converts a view model origin to a view url.
     * Used by the ConventionalViewStrategy.
@@ -994,11 +991,23 @@ export declare class ViewLocator {
   convertOriginToViewUrl(origin: Origin): string;
 }
 
+export declare interface LetExpression {
+  createBinding(): LetBinding
+}
+
+export declare interface LetBinding {
+  updateSource(): any;
+  call(context): any;
+  bind(source?: any): any;
+  unbind(): any;
+  connect(): any;
+}
+
 /**
 * An abstract base class for implementations of a binding language.
 */
 export declare class BindingLanguage {
-  
+
   /**
     * Inspects an attribute for bindings.
     * @param resources The ViewResources for the view being compiled.
@@ -1008,7 +1017,7 @@ export declare class BindingLanguage {
     * @return An info object with the results of the inspection.
     */
   inspectAttribute(resources: ViewResources, elementName: string, attrName: string, attrValue: string): Object;
-  
+
   /**
     * Creates an attribute behavior instruction.
     * @param resources The ViewResources for the view being compiled.
@@ -1018,7 +1027,16 @@ export declare class BindingLanguage {
     * @return The instruction instance.
     */
   createAttributeInstruction(resources: ViewResources, element: Element, info: Object, existingInstruction?: Object): BehaviorInstruction;
-  
+
+  /**
+   * Creates let expressions from a <let/> element
+   * @param resources The ViewResources for the view being compiled
+   * @param element the let element in the view template
+   * @param existingExpressions the array that will hold compiled let expressions from the let element
+   * @return the expression array created from the <let/> element
+   */
+  createLetExpressions(resources: ViewResources, element: Element, existingExpressions?: LetExpression[]): LetExpression[]
+
   /**
     * Parses the text for bindings.
     * @param resources The ViewResources for the view being compiled.
@@ -1077,73 +1095,73 @@ export declare function validateBehaviorName(name: string, type: string): any;
  * Will optinally add information to an existing HtmlBehaviorResource if given
  */
 export declare class ViewResources {
-  
+
   /**
      * Checks whether the provided class contains any resource conventions
      * @param target Target class to extract metadata based on convention
      * @param existing If supplied, all custom element / attribute metadata extracted from convention will be apply to this instance
      */
   static convention(target: Function, existing?: HtmlBehaviorResource): HtmlBehaviorResource | ValueConverterResource | BindingBehaviorResource | ViewEngineHooksResource;
-  
+
   /**
     * A custom binding language used in the view.
     */
   bindingLanguage: any;
-  
+
   /**
     * Creates an instance of ViewResources.
     * @param parent The parent resources. This resources can override them, but if a resource is not found, it will be looked up in the parent.
     * @param viewUrl The url of the view to which these resources apply.
     */
   constructor(parent?: ViewResources, viewUrl?: string);
-  
+
   /**
     * Registers view engine hooks for the view.
     * @param hooks The hooks to register.
     */
   registerViewEngineHooks(hooks: ViewEngineHooks): void;
-  
+
   /**
     * Gets the binding language associated with these resources, or return the provided fallback implementation.
     * @param bindingLanguageFallback The fallback binding language implementation to use if no binding language is configured locally.
     * @return The binding language.
     */
   getBindingLanguage(bindingLanguageFallback: BindingLanguage): BindingLanguage;
-  
+
   /**
     * Patches an immediate parent into the view resource resolution hierarchy.
     * @param newParent The new parent resources to patch in.
     */
   patchInParent(newParent: ViewResources): void;
-  
+
   /**
     * Maps a path relative to the associated view's origin.
     * @param path The relative path.
     * @return The calcualted path.
     */
   relativeToView(path: string): string;
-  
+
   /**
     * Registers an HTML element.
     * @param tagName The name of the custom element.
     * @param behavior The behavior of the element.
     */
   registerElement(tagName: string, behavior: HtmlBehaviorResource): void;
-  
+
   /**
     * Gets an HTML element behavior.
     * @param tagName The tag name to search for.
     * @return The HtmlBehaviorResource for the tag name or null.
     */
   getElement(tagName: string): HtmlBehaviorResource;
-  
+
   /**
     * Gets the known attribute name based on the local attribute name.
     * @param attribute The local attribute name to lookup.
     * @return The known name.
     */
   mapAttribute(attribute: string): string;
-  
+
   /**
     * Registers an HTML attribute.
     * @param attribute The name of the attribute.
@@ -1151,56 +1169,56 @@ export declare class ViewResources {
     * @param knownAttribute The well-known name of the attribute (in lieu of the local name).
     */
   registerAttribute(attribute: string, behavior: HtmlBehaviorResource, knownAttribute: string): void;
-  
+
   /**
     * Gets an HTML attribute behavior.
     * @param attribute The name of the attribute to lookup.
     * @return The HtmlBehaviorResource for the attribute or null.
     */
   getAttribute(attribute: string): HtmlBehaviorResource;
-  
+
   /**
     * Registers a value converter.
     * @param name The name of the value converter.
     * @param valueConverter The value converter instance.
     */
   registerValueConverter(name: string, valueConverter: Object): void;
-  
+
   /**
     * Gets a value converter.
     * @param name The name of the value converter.
     * @return The value converter instance.
     */
   getValueConverter(name: string): Object;
-  
+
   /**
     * Registers a binding behavior.
     * @param name The name of the binding behavior.
     * @param bindingBehavior The binding behavior instance.
     */
   registerBindingBehavior(name: string, bindingBehavior: Object): void;
-  
+
   /**
     * Gets a binding behavior.
     * @param name The name of the binding behavior.
     * @return The binding behavior instance.
     */
   getBindingBehavior(name: string): Object;
-  
+
   /**
     * Registers a value.
     * @param name The name of the value.
     * @param value The value.
     */
   registerValue(name: string, value: any): void;
-  
+
   /**
     * Gets a value.
     * @param name The name of the value.
     * @return The value.
     */
   getValue(name: string): any;
-  
+
   /**
      * @internal
      * Not supported for public use. Can be changed without warning.
@@ -1214,37 +1232,37 @@ export declare class ViewResources {
   autoRegister(container?: any, impl?: any): any;
 }
 export declare class View {
-  
+
   /**
     * The Dependency Injection Container that was used to create this View instance.
     */
   container: Container;
-  
+
   /**
     * The ViewFactory that built this View instance.
     */
   viewFactory: ViewFactory;
-  
+
   /**
     * Contains the DOM Nodes which represent this View. If the view was created via the "enhance" API, this will be an Element, otherwise it will be a DocumentFragment. If not created via "enhance" then the fragment will only contain nodes when the View is detached from the DOM.
     */
   fragment: DocumentFragment | Element;
-  
+
   /**
     * The primary binding context that this view is data-bound to.
     */
   bindingContext: Object;
-  
+
   /**
     * The override context which contains properties capable of overriding those found on the binding context.
     */
   overrideContext: Object;
-  
+
   /**
     * The Controller instance that owns this View.
     */
   controller: Controller;
-  
+
   /**
     * Creates a View instance.
     * @param container The container from which the view was created.
@@ -1255,57 +1273,57 @@ export declare class View {
     * @param children The children of this view.
     */
   constructor(container: Container, viewFactory: ViewFactory, fragment: DocumentFragment, controllers: Controller[], bindings: Binding[], children: ViewNode[], slots: Object);
-  
+
   /**
     * Returns this view to the appropriate view cache.
     */
   returnToCache(): void;
-  
+
   /**
     * Triggers the created callback for this view and its children.
     */
   created(): void;
-  
+
   /**
     * Binds the view and it's children.
     * @param bindingContext The binding context to bind to.
     * @param overrideContext A secondary binding context that can override the standard context.
     */
   bind(bindingContext: Object, overrideContext?: Object, _systemUpdate?: boolean): void;
-  
+
   /**
     * Adds a binding instance to this view.
     * @param binding The binding instance.
     */
   addBinding(binding: Object): void;
-  
+
   /**
     * Unbinds the view and its children.
     */
   unbind(): void;
-  
+
   /**
     * Inserts this view's nodes before the specified DOM node.
     * @param refNode The node to insert this view's nodes before.
     */
   insertNodesBefore(refNode: Node): void;
-  
+
   /**
     * Appends this view's to the specified DOM node.
     * @param parent The parent element to append this view's nodes to.
     */
   appendNodesTo(parent: Element): void;
-  
+
   /**
     * Removes this view's nodes from the DOM.
     */
   removeNodes(): void;
-  
+
   /**
     * Triggers the attach for the view and its children.
     */
   attached(): void;
-  
+
   /**
     * Triggers the detach for the view and its children.
     */
@@ -1317,7 +1335,7 @@ export declare class View {
 * Manages the view lifecycle for its children.
 */
 export declare class ViewSlot {
-  
+
   /**
     * Creates an instance of ViewSlot.
     * @param anchor The DOM node which will server as the anchor or container for insertion.
@@ -1325,7 +1343,7 @@ export declare class ViewSlot {
     * @param animator The animator that will controll enter/leave transitions for this slot.
     */
   constructor(anchor: Node, anchorIsContainer: boolean, animator?: Animator);
-  
+
   /**
      *   Runs the animator against the first animatable element found within the view's fragment
      *   @param  view       The view to use when searching for the element.
@@ -1333,32 +1351,32 @@ export declare class ViewSlot {
      *   @returns An animation complete Promise or undefined if no animation was run.
      */
   animateView(view: View, direction?: string): void | Promise<any>;
-  
+
   /**
     * Takes the child nodes of an existing element that has been converted into a ViewSlot
     * and makes those nodes into a View within the slot.
     */
   transformChildNodesIntoView(): void;
-  
+
   /**
     * Binds the slot and it's children.
     * @param bindingContext The binding context to bind to.
     * @param overrideContext A secondary binding context that can override the standard context.
     */
   bind(bindingContext: Object, overrideContext: Object): void;
-  
+
   /**
     * Unbinds the slot and its children.
     */
   unbind(): void;
-  
+
   /**
     * Adds a view to the slot.
     * @param view The view to add.
     * @return May return a promise if the view addition triggered an animation.
     */
   add(view: View): void | Promise<any>;
-  
+
   /**
     * Inserts a view into the slot.
     * @param index The index to insert the view at.
@@ -1366,14 +1384,14 @@ export declare class ViewSlot {
     * @return May return a promise if the view insertion triggered an animation.
     */
   insert(index: number, view: View): void | Promise<any>;
-  
+
   /**
      * Moves a view across the slot.
      * @param sourceIndex The index the view is currently at.
      * @param targetIndex The index to insert the view at.
      */
   move(sourceIndex?: any, targetIndex?: any): any;
-  
+
   /**
     * Removes a view from the slot.
     * @param view The view to remove.
@@ -1382,7 +1400,7 @@ export declare class ViewSlot {
     * @return May return a promise if the view removal triggered an animation.
     */
   remove(view: View, returnToCache?: boolean, skipAnimation?: boolean): View | Promise<View>;
-  
+
   /**
     * Removes many views from the slot.
     * @param viewsToRemove The array of views to remove.
@@ -1391,7 +1409,7 @@ export declare class ViewSlot {
     * @return May return a promise if the view removal triggered an animation.
     */
   removeMany(viewsToRemove: View[], returnToCache?: boolean, skipAnimation?: boolean): void | Promise<void>;
-  
+
   /**
     * Removes a view an a specified index from the slot.
     * @param index The index to remove the view at.
@@ -1400,7 +1418,7 @@ export declare class ViewSlot {
     * @return May return a promise if the view removal triggered an animation.
     */
   removeAt(index: number, returnToCache?: boolean, skipAnimation?: boolean): View | Promise<View>;
-  
+
   /**
     * Removes all views from the slot.
     * @param returnToCache Should the view be returned to the view cache?
@@ -1408,12 +1426,12 @@ export declare class ViewSlot {
     * @return May return a promise if the view removals triggered an animation.
     */
   removeAll(returnToCache?: boolean, skipAnimation?: boolean): void | Promise<any>;
-  
+
   /**
     * Triggers the attach for the slot and its children.
     */
   attached(): void;
-  
+
   /**
     * Triggers the detach for the slot and its children.
     */
@@ -1425,7 +1443,7 @@ export declare class ViewSlot {
 * A factory capable of creating View instances, bound to a location within another view hierarchy.
 */
 export declare class BoundViewFactory {
-  
+
   /**
     * Creates an instance of BoundViewFactory.
     * @param parentContainer The parent DI container.
@@ -1433,31 +1451,31 @@ export declare class BoundViewFactory {
     * @param partReplacements Part replacement overrides for the internal factory.
     */
   constructor(parentContainer: Container, viewFactory: ViewFactory, partReplacements?: Object);
-  
+
   /**
     * Creates a view or returns one from the internal cache, if available.
     * @return The created view.
     */
   create(): View;
-  
+
   /**
     * Indicates whether this factory is currently using caching.
     */
   isCaching: any;
-  
+
   /**
     * Sets the cache size for this factory.
     * @param size The number of views to cache or "*" to cache all.
     * @param doNotOverrideIfAlreadySet Indicates that setting the cache should not override the setting if previously set.
     */
   setCacheSize(size: number | string, doNotOverrideIfAlreadySet: boolean): void;
-  
+
   /**
     * Gets a cached view if available...
     * @return A cached view or null if one isn't available.
     */
   getCachedView(): View;
-  
+
   /**
     * Returns a view to the cache.
     * @param view The view to return to the cache if space is available.
@@ -1465,43 +1483,48 @@ export declare class BoundViewFactory {
   returnViewToCache(view: View): void;
 }
 
+interface ViewFactoryInstructions {
+  [x: number]: TargetInstruction
+  letExpressions: LetExpression[]
+}
+
 /**
 * A factory capable of creating View instances.
 */
 export declare class ViewFactory {
-  
+
   /**
     * Indicates whether this factory is currently using caching.
     */
   isCaching: any;
-  
+
   /**
     * Creates an instance of ViewFactory.
     * @param template The document fragment that serves as a template for the view to be created.
-    * @param instructions The instructions to be applied ot the template during the creation of a view.
+    * @param instructions The instructions to be applied on the template during the creation of a view.
     * @param resources The resources used to compile this factory.
     */
-  constructor(template: DocumentFragment, instructions: Object, resources: ViewResources);
-  
+  constructor(template: DocumentFragment, instructions: ViewFactoryInstructions, resources: ViewResources);
+
   /**
     * Sets the cache size for this factory.
     * @param size The number of views to cache or "*" to cache all.
     * @param doNotOverrideIfAlreadySet Indicates that setting the cache should not override the setting if previously set.
     */
   setCacheSize(size: number | string, doNotOverrideIfAlreadySet: boolean): void;
-  
+
   /**
     * Gets a cached view if available...
     * @return A cached view or null if one isn't available.
     */
   getCachedView(): View;
-  
+
   /**
     * Returns a view to the cache.
     * @param view The view to return to the cache if space is available.
     */
   returnViewToCache(view: View): void;
-  
+
   /**
     * Creates a view or returns one from the internal cache, if available.
     * @param container The container to create the view from.
@@ -1516,14 +1539,14 @@ export declare class ViewFactory {
 * Compiles html templates, dom fragments and strings into ViewFactory instances, capable of instantiating Views.
 */
 export declare class ViewCompiler {
-  
+
   /**
     * Creates an instance of ViewCompiler.
     * @param bindingLanguage The default data binding language and syntax used during view compilation.
     * @param resources The global resources used during compilation when none are provided for compilation.
     */
   constructor(bindingLanguage: BindingLanguage, resources: ViewResources);
-  
+
   /**
     * Compiles an html template, dom fragment or string into ViewFactory instances, capable of instantiating Views.
     * @param source The template, fragment or string to compile.
@@ -1538,26 +1561,26 @@ export declare class ViewCompiler {
 * Represents a module with view resources.
 */
 export declare class ResourceModule {
-  
+
   /**
     * Creates an instance of ResourceModule.
     * @param moduleId The id of the module that contains view resources.
     */
   constructor(moduleId: string);
-  
+
   /**
     * Initializes the resources within the module.
     * @param container The dependency injection container usable during resource initialization.
     */
   initialize(container: Container): void;
-  
+
   /**
     * Registers the resources in the module with the view resources.
     * @param registry The registry of view resources to regiser within.
     * @param name The name to use in registering the default resource.
     */
   register(registry: ViewResources, name?: string): void;
-  
+
   /**
     * Loads any dependencies of the resources within this module.
     * @param container The DI container to use during dependency resolution.
@@ -1571,7 +1594,7 @@ export declare class ResourceModule {
 * Represents a single view resource with a ResourceModule.
 */
 export declare class ResourceDescription {
-  
+
   /**
     * Creates an instance of ResourceDescription.
     * @param key The key that the resource was exported as.
@@ -1579,20 +1602,20 @@ export declare class ResourceDescription {
     * @param resourceTypeMeta The metadata located on the resource.
     */
   constructor(key: string, exportedValue: any, resourceTypeMeta?: Object);
-  
+
   /**
     * Initializes the resource.
     * @param container The dependency injection container usable during resource initialization.
     */
   initialize(container: Container): void;
-  
+
   /**
     * Registrers the resource with the view resources.
     * @param registry The registry of view resources to regiser within.
     * @param name The name to use in registering the resource.
     */
   register(registry: ViewResources, name?: string): void;
-  
+
   /**
     * Loads any dependencies of the resource.
     * @param container The DI container to use during dependency resolution.
@@ -1606,19 +1629,19 @@ export declare class ResourceDescription {
 * Analyzes a module in order to discover the view resources that it exports.
 */
 export declare class ModuleAnalyzer {
-  
+
   /**
     * Creates an instance of ModuleAnalyzer.
     */
   constructor();
-  
+
   /**
     * Retrieves the ResourceModule analysis for a previously analyzed module.
     * @param moduleId The id of the module to lookup.
     * @return The ResouceModule if found, undefined otherwise.
     */
   getAnalysis(moduleId: string): ResourceModule;
-  
+
   /**
     * Analyzes a module.
     * @param moduleId The id of the module to analyze.
@@ -1633,12 +1656,12 @@ export declare class ModuleAnalyzer {
 * Controls the view resource loading pipeline.
 */
 export declare class ViewEngine {
-  
+
   /**
     * The metadata key for storing requires declared in a ViewModel.
     */
   static viewModelRequireMetadataKey: any;
-  
+
   /**
     * Creates an instance of ViewEngine.
     * @param loader The module loader.
@@ -1648,14 +1671,14 @@ export declare class ViewEngine {
     * @param appResources The app-level global resources.
     */
   constructor(loader: Loader, container: Container, viewCompiler: ViewCompiler, moduleAnalyzer: ModuleAnalyzer, appResources: ViewResources);
-  
+
   /**
     * Adds a resource plugin to the resource loading pipeline.
     * @param extension The file extension to match in require elements.
     * @param implementation The plugin implementation that handles the resource type.
     */
   addResourcePlugin(extension: string, implementation: Object): void;
-  
+
   /**
     * Loads and compiles a ViewFactory from a url or template registry entry.
     * @param urlOrRegistryEntry A url or template registry entry to generate the view factory for.
@@ -1665,7 +1688,7 @@ export declare class ViewEngine {
     * @return A promise for the compiled view factory.
     */
   loadViewFactory(urlOrRegistryEntry: string | TemplateRegistryEntry, compileInstruction?: ViewCompileInstruction, loadContext?: ResourceLoadContext, target?: any): Promise<ViewFactory>;
-  
+
   /**
     * Loads all the resources specified by the registry entry.
     * @param registryEntry The template registry entry to load the resources for.
@@ -1675,7 +1698,7 @@ export declare class ViewEngine {
     * @return A promise of ViewResources for the registry entry.
     */
   loadTemplateResources(registryEntry: TemplateRegistryEntry, compileInstruction?: ViewCompileInstruction, loadContext?: ResourceLoadContext, target?: any): Promise<ViewResources>;
-  
+
   /**
     * Loads a view model as a resource.
     * @param moduleImport The module to import.
@@ -1683,7 +1706,7 @@ export declare class ViewEngine {
     * @return A promise for the ResourceDescription.
     */
   importViewModelResource(moduleImport: string, moduleMember: string): Promise<ResourceDescription>;
-  
+
   /**
     * Imports the specified resources with the specified names into the view resources object.
     * @param moduleIds The modules to load.
@@ -1699,23 +1722,23 @@ export declare class ViewEngine {
 * Controls a view model (and optionally its view), according to a particular behavior and by following a set of instructions.
 */
 export declare class Controller {
-  
+
   /**
     * The HtmlBehaviorResource that provides the base behavior for this controller.
     */
   behavior: HtmlBehaviorResource;
-  
+
   /**
     * The developer's view model instance which provides the custom behavior for this controller.
     */
   viewModel: Object;
-  
+
   /**
     * The view associated with the component being controlled by this controller.
     * Note: Not all components will have a view, so the value may be null.
     */
   view: View;
-  
+
   /**
     * Creates an instance of Controller.
     * @param behavior The HtmlBehaviorResource that provides the base behavior for this controller.
@@ -1724,13 +1747,13 @@ export declare class Controller {
     * @param container The container that the controller's view was created from.
     */
   constructor(behavior: HtmlBehaviorResource, instruction: BehaviorInstruction, viewModel: Object, container: Container);
-  
+
   /**
     * Invoked when the view which contains this controller is created.
     * @param owningView The view inside which this controller resides.
     */
   created(owningView: View): void;
-  
+
   /**
     * Used to automate the proper binding of this controller and its view. Used by the composition engine for dynamic component creation.
     * This should be considered a semi-private API and is subject to change without notice, even across minor or patch releases.
@@ -1738,23 +1761,23 @@ export declare class Controller {
     * @param owningView The view inside which this controller resides.
     */
   automate(overrideContext?: Object, owningView?: View): void;
-  
+
   /**
     * Binds the controller to the scope.
     * @param scope The binding scope.
     */
   bind(scope: Object): void;
-  
+
   /**
     * Unbinds the controller.
     */
   unbind(): void;
-  
+
   /**
     * Attaches the controller.
     */
   attached(): void;
-  
+
   /**
     * Detaches the controller.
     */
@@ -1765,7 +1788,7 @@ export declare class Controller {
 * An implementation of Aurelia's Observer interface that is used to back bindable properties defined on a behavior.
 */
 export declare class BehaviorPropertyObserver {
-  
+
   /**
     * Creates an instance of BehaviorPropertyObserver.
     * @param taskQueue The task queue used to schedule change notifications.
@@ -1775,30 +1798,30 @@ export declare class BehaviorPropertyObserver {
     * @param initialValue The initial value of the property.
     */
   constructor(taskQueue: TaskQueue, obj: Object, propertyName: string, selfSubscriber: Function, initialValue: any);
-  
+
   /**
     * Gets the property's value.
     */
   getValue(): any;
-  
+
   /**
     * Sets the property's value.
     * @param newValue The new value to set.
     */
   setValue(newValue: any): void;
-  
+
   /**
     * Invoked by the TaskQueue to publish changes to subscribers.
     */
   call(): void;
-  
+
   /**
     * Subscribes to the observerable.
     * @param context A context object to pass along to the subscriber when it's called.
     * @param callable A function or object with a "call" method to be invoked for delivery of changes.
     */
   subscribe(context: any, callable: Function): void;
-  
+
   /**
     * Unsubscribes from the observerable.
     * @param context The context object originally subscribed with.
@@ -1811,13 +1834,13 @@ export declare class BehaviorPropertyObserver {
 * Represents a bindable property on a behavior.
 */
 export declare class BindableProperty {
-  
+
   /**
     * Creates an instance of BindableProperty.
     * @param nameOrConfig The name of the property or a cofiguration object.
     */
   constructor(nameOrConfig: string | Object);
-  
+
   /**
     * Registers this bindable property with particular Class and Behavior instance.
     * @param target The class to register this behavior with.
@@ -1825,14 +1848,14 @@ export declare class BindableProperty {
     * @param descriptor The property descriptor for this property.
     */
   registerWith(target: Function, behavior: HtmlBehaviorResource, descriptor?: Object): void;
-  
+
   /**
     * Defines this property on the specified class and behavior.
     * @param target The class to define the property on.
     * @param behavior The behavior to define the property on.
     */
   defineOn(target: Function, behavior: HtmlBehaviorResource): void;
-  
+
   /**
     * Creates an observer for this property.
     * @param viewModel The view model instance on which to create the observer.
@@ -1846,25 +1869,25 @@ export declare class BindableProperty {
 * attribute functionality.
 */
 export declare class HtmlBehaviorResource {
-  
+
   /**
     * Creates an instance of HtmlBehaviorResource.
     */
   constructor();
-  
+
   /**
     * Checks whether the provided name matches any naming conventions for HtmlBehaviorResource.
     * @param name The name of the potential resource.
     * @param existing An already existing resource that may need a convention name applied.
     */
   static convention(name: string, existing?: HtmlBehaviorResource): HtmlBehaviorResource;
-  
+
   /**
     * Adds a binding expression to the component created by this resource.
     * @param behavior The binding expression.
     */
   addChildBinding(behavior: Object): void;
-  
+
   /**
     * Provides an opportunity for the resource to initialize iteself.
     * @param container The dependency injection container from which the resource
@@ -1872,7 +1895,7 @@ export declare class HtmlBehaviorResource {
     * @param target The class to which this resource metadata is attached.
     */
   initialize(container: Container, target: Function): void;
-  
+
   /**
     * Allows the resource to be registered in the view resources for the particular
     * view into which it was required.
@@ -1881,7 +1904,7 @@ export declare class HtmlBehaviorResource {
     * particular view it's being used.
     */
   register(registry: ViewResources, name?: string): void;
-  
+
   /**
     * Enables the resource to asynchronously load additional resources.
     * @param container The dependency injection container from which the resource
@@ -1893,7 +1916,7 @@ export declare class HtmlBehaviorResource {
     * permanently tied to this component.
     */
   load(container: Container, target: Function, loadContext?: ResourceLoadContext, viewStrategy?: ViewStrategy, transientView?: boolean): Promise<HtmlBehaviorResource>;
-  
+
   /**
     * Plugs into the compiler and enables custom processing of the node on which this behavior is located.
     * @param compiler The compiler that is currently compiling the view that this behavior exists within.
@@ -1904,7 +1927,7 @@ export declare class HtmlBehaviorResource {
     * @return The current node.
     */
   compile(compiler: ViewCompiler, resources: ViewResources, node: Node, instruction: BehaviorInstruction, parentNode?: Node): Node;
-  
+
   /**
     * Creates an instance of this behavior.
     * @param container The DI container to create the instance in.
@@ -1931,27 +1954,27 @@ export declare const SwapStrategies: any;
 * Used to dynamically compose components.
 */
 export declare class CompositionEngine {
-  
+
   /**
     * Creates an instance of the CompositionEngine.
     * @param viewEngine The ViewEngine used during composition.
     */
   constructor(viewEngine: ViewEngine, viewLocator: ViewLocator);
-  
+
   /**
     * Creates a controller instance for the component described in the context.
     * @param context The CompositionContext that describes the component.
     * @return A Promise for the Controller.
     */
   createController(context: CompositionContext): Promise<Controller>;
-  
+
   /**
     * Ensures that the view model and its resource are loaded for this context.
     * @param context The CompositionContext to load the view model and its resource for.
     * @return A Promise for the context.
     */
   ensureViewModel(context: CompositionContext): Promise<CompositionContext>;
-  
+
   /**
     * Dynamically composes a component.
     * @param context The CompositionContext providing information on how the composition should occur.
@@ -1966,7 +1989,7 @@ export declare class CompositionEngine {
 * to Web Components.
 */
 export declare class ElementConfigResource {
-  
+
   /**
     * Provides an opportunity for the resource to initialize iteself.
     * @param container The dependency injection container from which the resource
@@ -1974,7 +1997,7 @@ export declare class ElementConfigResource {
     * @param target The class to which this resource metadata is attached.
     */
   initialize(container: Container, target: Function): void;
-  
+
   /**
     * Allows the resource to be registered in the view resources for the particular
     * view into which it was required.
@@ -1983,7 +2006,7 @@ export declare class ElementConfigResource {
     * particular view it's being used.
     */
   register(registry: ViewResources, name?: string): void;
-  
+
   /**
     * Enables the resource to asynchronously load additional resources.
     * @param container The dependency injection container from which the resource
@@ -2121,7 +2144,7 @@ export declare function viewResources(...resources: any[]): any;
 * A facade of the templating engine capabilties which provides a more user friendly API for common use cases.
 */
 export declare class TemplatingEngine {
-  
+
   /**
     * Creates an instance of TemplatingEngine.
     * @param container The root DI container.
@@ -2130,13 +2153,13 @@ export declare class TemplatingEngine {
     * @param compositionEngine The composition engine used during dynamic component composition.
     */
   constructor(container: Container, moduleAnalyzer: ModuleAnalyzer, viewCompiler: ViewCompiler, compositionEngine: CompositionEngine);
-  
+
   /**
      * Configures the default animator.
      * @param animator The animator instance.
      */
   configureAnimator(animator: Animator): void;
-  
+
   /**
      * Dynamically composes components and views.
      * @param context The composition context to use.
@@ -2144,7 +2167,7 @@ export declare class TemplatingEngine {
      * are responsible for enforcing the Controller/View lifecycle.
      */
   compose(context: CompositionContext): Promise<View | Controller>;
-  
+
   /**
      * Enhances existing DOM with behaviors and bindings.
      * @param instruction The element to enhance or a set of instructions for the enhancement process.

--- a/doc/article/en-US/templating-custom-elements.md
+++ b/doc/article/en-US/templating-custom-elements.md
@@ -222,7 +222,7 @@ In this example, the `secret-message` custom element will check every ten second
 
 Whether a secret message that is only shown to the person who writes the message is very useful is for you to decide.
 
-## [Declarative computed value]
+## Declarative computed value
 
 As your application grows, custom elements get complicated and often values that are computed based on other values start to appear. It can be done either via getter in your custom element view model, or via aurelia `let` element. Think about it like a declaration in a JavaScript expression. For instance, a name tag form example would consist of two input fields with value bound to view model properties `firstName` and `lastName`, like the following example:
 
@@ -329,7 +329,22 @@ Or an expression:
   </source-code>
 </code-listing>
 
-And now after either `firstName` or `lastName` has changed, `fullName` is recomputed automatically and is ready to be used in other part of the view model. Now instead of reacting to changes on both `firstName` and `lastName`, we only need to care about `fullName` like the following example
+And now after either `firstName` or `lastName` has changed, `fullName` is recomputed automatically and is ready to be used in other part of the view model.
+
+Additonally, if there is needs to react to changes on both `fullName`, we can specify a special attribute `to-binding-context` on `<let/>` element to notify bindings to assign the value to binding context, which is your view model, instead of override context, which is your view.
+
+<code-listing heading="declarative-computed${context.language.fileExtension}">
+  <source-code lang="HTML">
+    <let to-binding-context full-name="${firstName} ${lastName}">
+    <div>
+      First name:
+      <input value.bind="firstName" />
+      Last name:
+      <input value.bind="lastName" />
+    </div>
+    Full name is: "${fullName}"
+  </source-code>
+</code-listing>
 
 <code-listing heading="declarative-computed${context.language.fileExtension}">
   <source-code lang="ES 2016">
@@ -337,7 +352,7 @@ And now after either `firstName` or `lastName` has changed, `fullName` is recomp
       @bindable firstName
       @bindable lastName
 
-      @bindable fullName
+      @observable fullName
 
       // Aurelia convention, called after fullName has changed
       fullNameNameChanged(fullName) {
@@ -350,7 +365,7 @@ And now after either `firstName` or `lastName` has changed, `fullName` is recomp
       @bindable firstName: string
       @bindable lastName: string
 
-      @bindable fullName: string
+      @observable fullName: string
 
       // Aurelia convention, called after fullName has changed
       fullNameNameChanged(fullName: string) {

--- a/src/binding-language.js
+++ b/src/binding-language.js
@@ -2,6 +2,18 @@ function mi(name) {
   throw new Error(`BindingLanguage must implement ${name}().`);
 }
 
+export interface LetExpression {
+  createBinding(): LetBinding
+}
+
+export interface LetBinding {
+  updateSource(): any;
+  call(context): any;
+  bind(source?: any): any;
+  unbind(): any;
+  connect(): any;
+}
+
 /**
 * An abstract base class for implementations of a binding language.
 */
@@ -28,6 +40,17 @@ export class BindingLanguage {
   */
   createAttributeInstruction(resources: ViewResources, element: Element, info: Object, existingInstruction?: Object): BehaviorInstruction {
     mi('createAttributeInstruction');
+  }
+
+  /**
+   * Creates let expressions from a <let/> element
+   * @param resources The ViewResources for the view being compiled
+   * @param element the let element in the view template
+   * @param existingExpressions the array that will hold compiled let expressions from the let element
+   * @return the expression array created from the <let/> element
+   */
+  createLetExpressions(resources: ViewResources, element: Element, existingExpressions?: LetExpression[]): LetExpession[] {
+    mi('createLetExpressions');
   }
 
   /**

--- a/src/binding-language.js
+++ b/src/binding-language.js
@@ -62,7 +62,7 @@ export class BindingLanguage {
    * @param existingExpressions the array that will hold compiled let expressions from the let element
    * @return the expression array created from the <let/> element
    */
-  createLetExpressions(resources: ViewResources, element: Element, existingExpressions?: LetExpression[]): LetExpession[] {
+  createLetExpressions(resources: ViewResources, element: Element): LetExpession[] {
     mi('createLetExpressions');
   }
 

--- a/src/binding-language.js
+++ b/src/binding-language.js
@@ -1,17 +1,30 @@
+import { Scope } from 'aurelia-binding';
+
 function mi(name) {
   throw new Error(`BindingLanguage must implement ${name}().`);
 }
 
 interface LetExpression {
-  createBinding(): LetBinding
+  createBinding(): LetBinding;
 }
 
 interface LetBinding {
-  updateSource(): any;
-  call(context): any;
-  bind(source?: any): any;
-  unbind(): any;
-  connect(): any;
+  /**
+   * The expression to access/assign/connect the binding source property.
+   */
+  sourceExpression: Expression;
+  /**
+   * Assigns a value to the target.
+   */
+  updateTarget(value: any): void;
+  /**
+   * Connects the binding to a scope.
+   */
+  bind(source: Scope): void;
+  /**
+   * Disconnects the binding from a scope.
+   */
+  unbind(): void;
 }
 
 /**

--- a/src/binding-language.js
+++ b/src/binding-language.js
@@ -2,11 +2,11 @@ function mi(name) {
   throw new Error(`BindingLanguage must implement ${name}().`);
 }
 
-export interface LetExpression {
+interface LetExpression {
   createBinding(): LetBinding
 }
 
-export interface LetBinding {
+interface LetBinding {
   updateSource(): any;
   call(context): any;
   bind(source?: any): any;

--- a/src/instructions.js
+++ b/src/instructions.js
@@ -244,6 +244,23 @@ export class TargetInstruction {
   }
 
   /**
+  * Creates an instruction that represents an element with behaviors and bindings.
+  * @param injectorId The id of the dependency injection container.
+  * @param parentInjectorId The id of the parent dependency injection container.
+  * @param providers The types which will provide behavior for this element.
+  * @param behaviorInstructions The instructions for creating behaviors on this element.
+  * @param expressions Bindings, listeners, triggers, etc.
+  * @param elementInstruction The element behavior for this element.
+  * @return The created instruction.
+  */
+  static letElement(expressions: Array<Object>): TargetInstruction {
+    let instruction = new TargetInstruction();
+    instruction.expressions = expressions;
+    instruction.letElement = true;
+    return instruction;
+  }
+
+  /**
   * Creates an instruction that represents content that was lifted out of the DOM and into a ViewFactory.
   * @param parentInjectorId The id of the parent dependency injection container.
   * @param liftingInstruction The behavior instruction of the lifting behavior.

--- a/src/instructions.js
+++ b/src/instructions.js
@@ -161,27 +161,23 @@ export class BehaviorInstruction {
     instruction.inheritBindingContext = true;
     return instruction;
   }
-
-  /**
-  * Creates an instance of BehaviorInstruction.
-  */
-  constructor() {
-    this.initiatedByBehavior = false;
-    this.enhance = false;
-    this.partReplacements = null;
-    this.viewFactory = null;
-    this.originalAttrName = null;
-    this.skipContentProcessing = false;
-    this.contentFactory = null;
-    this.viewModel = null;
-    this.anchorIsContainer = false;
-    this.host = null;
-    this.attributes = null;
-    this.type = null;
-    this.attrName = null;
-    this.inheritBindingContext = false;
-  }
 }
+
+const biProto = BehaviorInstruction.prototype;
+biProto.initiatedByBehavior = false;
+biProto.enhance = false;
+biProto.partReplacements = null;
+biProto.viewFactory = null;
+biProto.originalAttrName = null;
+biProto.skipContentProcessing = false;
+biProto.contentFactory = null;
+biProto.viewModel = null;
+biProto.anchorIsContainer = false;
+biProto.host = null;
+biProto.attributes = null;
+biProto.type = null;
+biProto.attrName = null;
+biProto.inheritBindingContext = false;
 
 BehaviorInstruction.normal = new BehaviorInstruction();
 
@@ -190,26 +186,34 @@ BehaviorInstruction.normal = new BehaviorInstruction();
 */
 export class TargetInstruction {
 
-  injectorId:number;
-  parentInjectorId:number;
+  injectorId: number;
+  parentInjectorId: number;
 
-  shadowSlot:boolean;
-  slotName:string;
-  slotFallbackFactory:any;
+  shadowSlot: boolean;
+  slotName: string;
+  slotFallbackFactory: any;
 
-  contentExpression:any;
+  /**
+   * Indicates if this instruction is targeting a text node
+   */
+  contentExpression: any;
 
-  expressions:Array<Object>;
-  behaviorInstructions:Array<BehaviorInstruction>;
-  providers:Array<Function>;
+  /**
+   * Indicates if this instruction is a let element instruction
+   */
+  letElement: boolean;
 
-  viewFactory:ViewFactory;
+  expressions: Array<Object>;
+  behaviorInstructions: Array<BehaviorInstruction>;
+  providers: Array<Function>;
 
-  anchorIsContainer:boolean;
-  elementInstruction:BehaviorInstruction;
-  lifting:boolean;
+  viewFactory: ViewFactory;
 
-  values:Object;
+  anchorIsContainer: boolean;
+  elementInstruction: BehaviorInstruction;
+  lifting: boolean;
+
+  values: Object;
 
   /**
   * An empty array used to represent a target with no binding expressions.
@@ -294,30 +298,28 @@ export class TargetInstruction {
     instruction.values = values;
     return instruction;
   }
-
-  /**
-  * Creates an instance of TargetInstruction.
-  */
-  constructor() {
-    this.injectorId = null;
-    this.parentInjectorId = null;
-
-    this.shadowSlot = false;
-    this.slotName = null;
-    this.slotFallbackFactory = null;
-
-    this.contentExpression = null;
-
-    this.expressions = null;
-    this.behaviorInstructions = null;
-    this.providers = null;
-
-    this.viewFactory = null;
-
-    this.anchorIsContainer = false;
-    this.elementInstruction = null;
-    this.lifting = false;
-
-    this.values = null;
-  }
 }
+
+const tiProto = TargetInstruction.prototype;
+
+tiProto.injectorId = null;
+tiProto.parentInjectorId = null;
+
+tiProto.shadowSlot = false;
+tiProto.slotName = null;
+tiProto.slotFallbackFactory = null;
+
+tiProto.contentExpression = null;
+tiProto.letElement = false;
+
+tiProto.expressions = null;
+tiProto.expressions = null;
+tiProto.providers = null;
+
+tiProto.viewFactory = null;
+
+tiProto.anchorIsContainer = false;
+tiProto.elementInstruction = null;
+tiProto.lifting = false;
+
+tiProto.values = null;

--- a/src/templating-engine.js
+++ b/src/templating-engine.js
@@ -85,7 +85,7 @@ export class TemplatingEngine {
       instruction = { element: instruction };
     }
 
-    let compilerInstructions = {};
+    let compilerInstructions = { letExpressions: [] };
     let resources = instruction.resources || this._container.get(ViewResources);
 
     this._viewCompiler._compileNode(instruction.element, resources, compilerInstructions, instruction.element.parentNode, 'root', true);

--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -325,14 +325,19 @@ export class ViewCompiler {
       }
       return node.nextSibling;
     } else if (tagName === 'let') {
-      bindingLanguage.createLetExpressions(
-        resources,
-        node,
-        instructions.letExpressions
+      auTargetID = makeIntoInstructionTarget(node);
+      instructions[auTargetID] = TargetInstruction.normal(
+        undefined,
+        undefined,
+        providers,
+        behaviorInstructions,
+        bindingLanguage.createLetExpressions(
+          resources,
+          node,
+          instructions.letExpressions
+        )
       );
-      nextSib = node.nextSibling;
-      DOM.removeNode(node);
-      return nextSib;
+      return node.nextSibling;
     } else if (tagName === 'template') {
       if (!('content' in node)) {
         throw new Error('You cannot place a template element within ' + node.namespaceURI + ' namespace');

--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -1,4 +1,3 @@
-import {Binding} from 'aurelia-binding';
 import {ViewResources} from './view-resources';
 import {ViewFactory} from './view-factory';
 import {BindingLanguage} from './binding-language';
@@ -6,23 +5,6 @@ import {ViewCompileInstruction, BehaviorInstruction, TargetInstruction} from './
 import {inject} from 'aurelia-dependency-injection';
 import {DOM, FEATURE} from 'aurelia-pal';
 import {ShadowDOM} from './shadow-dom';
-
-interface LetExpression {
-  createBinding(): LetBinding
-}
-
-interface LetBinding extends Binding {
-  updateSource(): any;
-  call(context): any;
-  bind(source?: any): any;
-  unbind(): any;
-  connect(): any;
-}
-
-interface ViewFactoryInstructions {
-  [x: number]: TargetInstruction,
-  letExpressions: LetExpression[]
-}
 
 let nextInjectorId = 0;
 function getNextInjectorId() {
@@ -293,7 +275,7 @@ export class ViewCompiler {
     return null;
   }
 
-  _compileElement(node: Node, resources: ViewResources, instructions: ViewFactoryInstructions, parentNode: Node, parentInjectorId: number, targetLightDOM: boolean) {
+  _compileElement(node: Node, resources: ViewResources, instructions: any, parentNode: Node, parentInjectorId: number, targetLightDOM: boolean) {
     let tagName = node.tagName.toLowerCase();
     let attributes = node.attributes;
     let expressions = [];

--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -1,3 +1,4 @@
+import {Binding} from 'aurelia-binding';
 import {ViewResources} from './view-resources';
 import {ViewFactory} from './view-factory';
 import {BindingLanguage} from './binding-language';
@@ -10,7 +11,7 @@ interface LetExpression {
   createBinding(): LetBinding
 }
 
-interface LetBinding {
+interface LetBinding extends Binding {
   updateSource(): any;
   call(context): any;
   bind(source?: any): any;
@@ -111,7 +112,7 @@ export class ViewCompiler {
     compileInstruction.targetShadowDOM = compileInstruction.targetShadowDOM && FEATURE.shadowDOM;
     resources._invokeHook('beforeCompile', content, resources, compileInstruction);
 
-    let instructions = { letExpressions: [] };
+    let instructions = {};
     this._compileNode(content, resources, instructions, source, 'root', !compileInstruction.targetShadowDOM);
 
     let firstChild = content.firstChild;
@@ -317,7 +318,6 @@ export class ViewCompiler {
     let knownAttribute;
     let auTargetID;
     let injectorId;
-    let nextSib;
 
     if (tagName === 'slot') {
       if (targetLightDOM) {
@@ -326,11 +326,7 @@ export class ViewCompiler {
       return node.nextSibling;
     } else if (tagName === 'let') {
       auTargetID = makeIntoInstructionTarget(node);
-      instructions[auTargetID] = TargetInstruction.normal(
-        undefined,
-        undefined,
-        providers,
-        behaviorInstructions,
+      instructions[auTargetID] = TargetInstruction.letElement(
         bindingLanguage.createLetExpressions(
           resources,
           node,

--- a/src/view-factory.js
+++ b/src/view-factory.js
@@ -428,6 +428,7 @@ export class ViewFactory {
     let fragment = createInstruction.enhance ? this.template : this.template.cloneNode(true);
     let instructables = fragment.querySelectorAll('.au-target');
     let instructions = this.instructions;
+    let letExpressions = instructions.letExpressions;
     let resources = this.resources;
     let controllers = [];
     let bindings = [];
@@ -442,6 +443,10 @@ export class ViewFactory {
     let instruction;
 
     this.resources._invokeHook('beforeCreate', this, container, fragment, createInstruction);
+
+    for (i = 0, ii = letExpressions.length; ii > i; ++i) {
+      bindings.push(letExpressions[i].createBinding());
+    }
 
     if (element && this.surrogateInstruction !== null) {
       applySurrogateInstruction(container, element, this.surrogateInstruction, controllers, bindings, children);

--- a/src/view-factory.js
+++ b/src/view-factory.js
@@ -169,7 +169,7 @@ function applyInstructions(containers, element, instruction, controllers, bindin
     return;
   }
 
-  if (instruction.letExpressions) {
+  if (instruction.letElement) {
     for (i = 0, ii = expressions.length; i < ii; ++i) {
       bindings.push(expressions[i].createBinding());
     }
@@ -447,7 +447,6 @@ export class ViewFactory {
     let fragment = createInstruction.enhance ? this.template : this.template.cloneNode(true);
     let instructables = fragment.querySelectorAll('.au-target');
     let instructions = this.instructions;
-    let letExpressions = instructions.letExpressions;
     let resources = this.resources;
     let controllers = [];
     let bindings = [];
@@ -462,10 +461,6 @@ export class ViewFactory {
     let instruction;
 
     this.resources._invokeHook('beforeCreate', this, container, fragment, createInstruction);
-
-    for (i = 0, ii = letExpressions.length; ii > i; ++i) {
-      bindings.push(letExpressions[i].createBinding());
-    }
 
     if (element && this.surrogateInstruction !== null) {
       applySurrogateInstruction(container, element, this.surrogateInstruction, controllers, bindings, children);

--- a/src/view-factory.js
+++ b/src/view-factory.js
@@ -126,6 +126,17 @@ function makeElementIntoAnchor(element, elementInstruction) {
   return anchor;
 }
 
+/**
+ * @param {Container[]} containers
+ * @param {Element} element
+ * @param {TargetInstruction} instruction
+ * @param {Controller[]} controllers
+ * @param {Binding[]} bindings
+ * @param {ViewNode[]} children
+ * @param {Record<string, ShadowSlot>} shadowSlots
+ * @param {Record<string, ViewFactory>} partReplacements
+ * @param {ViewResources} resources
+ */
 function applyInstructions(containers, element, instruction, controllers, bindings, children, shadowSlots, partReplacements, resources) {
   let behaviorInstructions = instruction.behaviorInstructions;
   let expressions = instruction.expressions;
@@ -155,6 +166,14 @@ function applyInstructions(containers, element, instruction, controllers, bindin
     DOM.replaceNode(commentAnchor, element);
     shadowSlots[instruction.slotName] = slot;
     controllers.push(slot);
+    return;
+  }
+
+  if (instruction.letExpressions) {
+    for (i = 0, ii = expressions.length; i < ii; ++i) {
+      bindings.push(expressions[i].createBinding());
+    }
+    element.parentNode.removeChild(element);
     return;
   }
 

--- a/test/util.js
+++ b/test/util.js
@@ -1,0 +1,5 @@
+export function createFragment(html) {
+  const parser = document.createElement('div');
+  parser.innerHTML = `<template>${html}</template>`;
+  return parser.removeChild(parser.firstElementChild).content;
+}

--- a/test/view-compiler.spec.js
+++ b/test/view-compiler.spec.js
@@ -21,7 +21,7 @@ class MockBindingLanguage {
 
 describe('ViewCompiler', () => {
   var viewCompiler, language, resources;
-  beforeAll(() => {
+  beforeEach(() => {
     language = new MockBindingLanguage();
     viewCompiler = new ViewCompiler(language);
     resources = new ViewResources(new ViewResources(), 'app.html');
@@ -136,19 +136,24 @@ describe('ViewCompiler', () => {
     });
 
     it('compiles let element by extracting bindings and remove the element', () => {
-      let instructions = { letExpressions: [] };
-      let parentInjectorId = 'root';
-      let targetLightDOM = true;
+      let instructions = { };
 
-      let node = document.createElement('let');
+      let letElement = document.createElement('let');
       let parentNode = document.createElement('div');
 
-      parentNode.appendChild(node);
-      node.setAttribute('foo', 'bar');
+      parentNode.appendChild(letElement);
+      letElement.setAttribute('foo', 'bar');
 
-      viewCompiler._compileNode(node, resources, instructions, parentNode, 'root', true);
-      expect(parentNode.hasChildNodes()).toBe(false);
-      expect(instructions.letExpressions.length).toBe(1);
+      viewCompiler._compileNode(letElement, resources, instructions, parentNode, 'root', true);
+      expect(Object.keys(instructions).length).toBe(1, 'It should have had 1 instruction');
+      let instruction;
+      // id in view compiler is universal across instances, cannot reset
+      for (var id in instructions) {
+        instruction = instructions[id];
+      }
+      expect(instruction).toBeDefined('First instruction should have been defined');
+      expect(instruction.letElement).toBe(true, 'Type of instruction should have been letElement');
+      expect(instruction.expressions.length).toBe(1, 'Should have had 1 expression');
     });
 
   });

--- a/test/view-compiler.spec.js
+++ b/test/view-compiler.spec.js
@@ -9,6 +9,12 @@ class MockBindingLanguage {
   createAttributeInstruction(resources, element, info, existingInstruction) {
   }
 
+  createLetExpressions(resources, element, existingExpressions) {
+    existingExpressions = existingExpressions || [];
+    existingExpressions.push({ createBinding() {} });
+    return existingExpressions;
+  }
+
   inspectTextContent(resources, value) {
   }
 }
@@ -127,6 +133,22 @@ describe('ViewCompiler', () => {
 
       viewCompiler._compileNode(node, resources, instructions, parentNode, parentInjectorId, targetLightDOM);
       expect(node.className).toBe('foo bar baz au-target');
+    });
+
+    it('compiles let element by extracting bindings and remove the element', () => {
+      let instructions = { letExpressions: [] };
+      let parentInjectorId = 'root';
+      let targetLightDOM = true;
+
+      let node = document.createElement('let');
+      let parentNode = document.createElement('div');
+
+      parentNode.appendChild(node);
+      node.setAttribute('foo', 'bar');
+
+      viewCompiler._compileNode(node, resources, instructions, parentNode, 'root', true);
+      expect(parentNode.hasChildNodes()).toBe(false);
+      expect(instructions.letExpressions.length).toBe(1);
     });
 
   });

--- a/test/view-factory.spec.js
+++ b/test/view-factory.spec.js
@@ -1,0 +1,128 @@
+import { ViewFactory } from "../src/view-factory";
+import { Container } from "aurelia-dependency-injection";
+import { ViewCompiler } from "../src/view-compiler";
+import { ViewResources } from "../src/view-resources";
+import { createFragment } from './util';
+import { TargetInstruction } from "../src/instructions";
+
+describe('ViewFactory', () => {
+
+  it('constructs', () => {
+    [null, undefined, 'string', {}, 1].forEach(v => {
+      expect(() => new ViewFactory(v, v, v, v)).not.toThrow();
+    });
+  });
+
+  describe('create()', () => {
+    /**@type {Container} */
+    let container;
+    // /**@type {ViewCompiler} */
+    // let compiler;
+    /**@type {ViewFactory} */
+    let viewFactory;
+
+    beforeEach(() => {
+      container = new Container();
+      // compiler = container.get(ViewCompiler);
+      // compiler.bindingLanguage.inspectTextContent = function() {
+      //   return {
+      //     createBinding() {
+      //       return { bind() {}, unbind() {} };
+      //     }
+      //   }
+      // };
+      // compiler.bindingLanguage.inspectAttribute = function inspectAttribute(resources, tagName, attrName, attrValue) {
+      //   return { attrName, attrValue };
+      // }
+    });
+
+    it('creates', () => {
+      const binding = {};
+      viewFactory = new ViewFactory(
+        createFragment('<div class="au-target" au-target-id="1"></div>'),
+        {
+          1: {
+            behaviorInstructions: [],
+            expressions: [
+              {
+                createBinding(target) {
+                  binding.target = target;
+                  return binding;
+                }
+              }
+            ],
+          }
+        },
+        container.get(ViewResources)
+      );
+      const view = viewFactory.create(container);
+      expect(view.bindings).toBeDefined();
+      expect(view.bindings.length).toBe(1, 'It should have had 1 binding');
+      const target = binding.target;
+      expect(target instanceof Element).toBe(true, 'It should have had the target');
+      expect(target.className).toBe('au-target');
+    });
+
+    describe('<let/>', () => {
+
+      it('creates with <let/>', () => {
+        const binding = {};
+        const unset = {};
+        viewFactory = new ViewFactory(
+          createFragment(`<let class="au-target" au-target-id="1"></let>`),
+          {
+            1: TargetInstruction.letElement([
+              { createBinding(target) {
+                binding.target = arguments.length === 0 ? unset : target;
+                return binding;
+              }}
+            ])
+          },
+          container.get(ViewResources)
+        );
+        const view = viewFactory.create(container);
+        expect(view.bindings).toBeDefined();
+        expect(view.bindings.length).toBe(1, 'It should have had 1 binding');
+        const target = binding.target;
+        expect(target).toBe(unset, 'It should have had no target in createBinding()');
+        expect(view.firstChild).toBe(null, '<let/> element should have been removed');
+      });
+
+      it('creates with multiple <let/>', () => {
+        const binding = {};
+        const unset = {};
+        viewFactory = new ViewFactory(
+          createFragment(`
+            <let class="au-target" au-target-id="1"></let>
+            <div>
+              <let class="au-target" au-target-id="2"></let>
+            </div>
+            <div>
+              <let class="au-target" au-target-id="3"></let>
+            </div>
+          `),
+          {
+            1: TargetInstruction.letElement([
+              createLetExpression({ a: 1 })
+            ]),
+            2: TargetInstruction.letElement([
+              createLetExpression({ a: 2 })
+            ]),
+            3: TargetInstruction.letElement([
+              createLetExpression({ a: 3 })
+            ]),
+          },
+          container.get(ViewResources)
+        );
+        const view = viewFactory.create(container);
+        expect(view.bindings).toBeDefined();
+        expect(view.bindings.length).toBe(3, 'It should have had 1 binding');
+        expect(view.bindings.every(b => 'a' in b)).toBe(true, 'It should have created multiple let bindings');
+      });
+    });
+
+    function createLetExpression(binding) {
+      return { createBinding() { return binding } };
+    }
+  });
+});

--- a/test/view-slot.spec.js
+++ b/test/view-slot.spec.js
@@ -35,7 +35,7 @@ describe('view-slot', () => {
     let factory;
 
     beforeEach(() => {
-      compilerInstructions = {};
+      compilerInstructions = { letExpressions: [] };
       resources = container.get(ViewResources);
       factory = new ViewFactory(parent, compilerInstructions, resources);
       view = factory.create();
@@ -102,7 +102,7 @@ describe('view-slot', () => {
     let factory;
 
     beforeEach(() => {
-      compilerInstructions = {};
+      compilerInstructions = { letExpressions: [] };
       resources = container.get(ViewResources);
       factory = new ViewFactory(parent, compilerInstructions, resources);
       view = factory.create();

--- a/test/view-slot.spec.js
+++ b/test/view-slot.spec.js
@@ -35,7 +35,7 @@ describe('view-slot', () => {
     let factory;
 
     beforeEach(() => {
-      compilerInstructions = { letExpressions: [] };
+      compilerInstructions = {};
       resources = container.get(ViewResources);
       factory = new ViewFactory(parent, compilerInstructions, resources);
       view = factory.create();
@@ -102,7 +102,7 @@ describe('view-slot', () => {
     let factory;
 
     beforeEach(() => {
-      compilerInstructions = { letExpressions: [] };
+      compilerInstructions = {};
       resources = container.get(ViewResources);
       factory = new ViewFactory(parent, compilerInstructions, resources);
       view = factory.create();


### PR DESCRIPTION
[Base discussion](https://github.com/aurelia/templating-binding/issues/115)

This is a step 1 to support let element.
Step 2 will be in `templating-binding` with implementation of let expression classes, and `createLetExpressions` for binding language.

requires aurelia/templating-binding#117

#### Usage

```html
<template>
  <let
    msg.bind='message'
    fun-message.bind='msg | fun'
    no-fun-message.bind='msg | noFun'
    sentence='Full name is: "${fullName}" and first name is "${firstName}" and last name is "${lastName}"'
    literal-string='I am a literal stirng in let element. Triggered warning.'></let>

  <!-- compute dayName on each loop bindingContext -->
  <div repeat.for='day of days'>
    <let day-name.bind='day | toShort'></let>
    <span>Day name: ${dayName}. Index: ${$index}</span>
  </div>
</template>
```