### PR TITLE
fix(view-engine): define metadata for SlotCustomAttribute

### DIFF
--- a/src/view-engine.js
+++ b/src/view-engine.js
@@ -75,6 +75,7 @@ export class ViewEngine {
 
     let auSlotBehavior = new HtmlBehaviorResource();
     auSlotBehavior.attributeName = 'au-slot';
+    metadata.define(metadata.resource, auSlotBehavior, SlotCustomAttribute);
     auSlotBehavior.initialize(container, SlotCustomAttribute);
     auSlotBehavior.register(appResources);
   }


### PR DESCRIPTION
fix #566
@EisenbergEffect I have some concerns about the fix, since `ViewEngine` *creates* and *initializes* the behavior instance:
- currently the relation is `au-slot` behavior instance per `ViewEngine` instance.
- defining the metadata changes this - now it's on the ` class SlotCustomAttribute`.
    - is it supported use case to have more than one instance of `ViewEngine` in an app(`enhance`)?
    - is it supported use case to have more than one apps running in parallel?