### PR TITLE
fix(view-compiler): use the hyphenated name of the primary property

### DIFF
--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -206,7 +206,7 @@ export class ViewCompiler {
             // (otherwise it will remain associated with "value")
             if (info.command && (info.command !== 'options') && type.primaryProperty) {
               const primaryProperty = type.primaryProperty;
-              attrName = info.attrName = primaryProperty.name;
+              attrName = info.attrName = primaryProperty.attribute;
               // note that the defaultBindingMode always overrides the attribute bindingMode which is only used for "single-value" custom attributes
               // when using the syntax `<div square.bind="color"></div>`
               info.defaultBindingMode = primaryProperty.defaultBindingMode;
@@ -351,7 +351,7 @@ export class ViewCompiler {
             // (otherwise it will remain associated with "value")
             if (info.command && (info.command !== 'options') && type.primaryProperty) {
               const primaryProperty = type.primaryProperty;
-              attrName = info.attrName = primaryProperty.name;
+              attrName = info.attrName = primaryProperty.attribute;
               // note that the defaultBindingMode always overrides the attribute bindingMode which is only used for "single-value" custom attributes
               // when using the syntax `<div square.bind="color"></div>`
               info.defaultBindingMode = primaryProperty.defaultBindingMode;


### PR DESCRIPTION
`BindableProperty.name` is the *camelCase* name, use  `BindableProperty.attribute` for the *kebab-case* name.
fix #576 