### PR TITLE
perf(child-observation) handle fast special case for wildcard (*) selector

### DIFF
--- a/src/child-observation.js
+++ b/src/child-observation.js
@@ -238,6 +238,12 @@ class ChildObserverBinder {
 
       if (this.all) {
         let items = (this.viewModel[this.property] || (this.viewModel[this.property] = []));
+
+        if (this.selector === '*') {
+          items.push(value);
+          return true;
+        }
+        
         let index = 0;
         let prev = element.previousElementSibling;
 


### PR DESCRIPTION
In the case with a significant portion of children (>2000), the `n+1` computation of the splice index becomes a significant overhead. This fix bypasses this computation in the special case when the selector is *.

I was unable to reliably build the dist output - it seems to have too many changes...

Before:
![before](https://user-images.githubusercontent.com/2112306/33366759-8f1c4488-d4ec-11e7-858d-f7f0be4f89d4.png)

After:
![after](https://user-images.githubusercontent.com/2112306/33366770-941f54ac-d4ec-11e7-9ffe-422984c30fa1.png)
