### PR TITLE
ViewCompiler: remove binding commands after compilation

### DIFF
--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -118,6 +118,7 @@ export class ViewCompiler {
       factory.setCacheSize(cacheSize);
     }
 
+    this._removeCommands(factory.template);
     resources._invokeHook('afterCompile', factory);
 
     return factory;
@@ -489,6 +490,22 @@ export class ViewCompiler {
           value.targetProperty = property.name;
         } else {
           value.targetProperty = key;
+        }
+      }
+    }
+  }
+
+  _removeCommands(template: DocumentFragment) {
+    const auTargets = template.querySelectorAll('.au-target');
+    for (let i = 0, ii = auTargets.length; ii > i; ++i) {
+      const auTarget = auTargets[i];
+      const attrs = auTarget.attributes;
+      for (let j = 0; attrs.length > j; ++j) {
+        const attr = attrs[j];
+        const attrName = attr.name;
+        if (attrName.indexOf('.') !== -1 || attrName === 'ref' || attrName === 'as-element') {
+          auTarget.removeAttribute(attrName);
+          j--;
         }
       }
     }

--- a/test/view-compiler.spec.js
+++ b/test/view-compiler.spec.js
@@ -42,6 +42,25 @@ describe('ViewCompiler', () => {
 
       expect(compileFunc).toThrow();
     });
+
+    it('removes binding commands and `ref`, `as-element`', () => {
+
+      let node = document.createDocumentFragment();
+      let input = node.appendChild(document.createElement('input'));
+      input.className = 'au-target';
+      input.setAttribute('value.bind', 'value');
+      input.setAttribute('ref', 'input');
+
+      let el = node.appendChild(document.createElement('div'));
+      el.className = 'au-target';
+      el.setAttribute('as-element', 'row');
+
+      viewCompiler._removeCommands(node);
+
+      expect(input.hasAttribute('value.bind')).toBe(false);
+      expect(input.hasAttribute('ref')).toBe(false);
+      expect(el.hasAttribute('as-element')).toBe(false);
+    });
   });
 
   describe('compileNode', () => {


### PR DESCRIPTION
It's an official way to clean up aurelia view. This mostly benefits `repeat`, the gain is small / maybe negative. example:

before:

```html
<input
  class="au-target"
  show.bind="condition"
  value.bind="..."
  focus.bind="..."
  au-target-id="1"/>
```

after

```html
  <input class="au-target" au-target-id="1"/>
```

Plugin that gives this functionality: https://github.com/lgabeskiria/aurelia-clean-bindings

benchmark at https://gist.run/?id=d4c665917deed8913b79bdc675c28cc3
