### PR TITLE
fix(BehaviorPropertyObserver): use Object.is() for comparison

### DIFF
--- a/src/behavior-property-observer.js
+++ b/src/behavior-property-observer.js
@@ -38,7 +38,7 @@ export class BehaviorPropertyObserver {
   setValue(newValue: any): void {
     let oldValue = this.currentValue;
 
-    if (oldValue !== newValue) {
+    if (Object.is(newValue, oldValue)) {
       this.oldValue = oldValue;
       this.currentValue = newValue;
 
@@ -62,7 +62,7 @@ export class BehaviorPropertyObserver {
 
     this.notqueued = true;
 
-    if (newValue === oldValue) {
+    if (Object.is(newValue, oldValue)) {
       return;
     }
 


### PR DESCRIPTION
* requires aurelia/polyfills#58
* resolves aurelia/binding#613

Performance shouldn't take any hit with native `Object.is` implementation, app using polyfill of `Object.is` will. Overall won't be a big deal and Aurelia will be more reliable as comparison between `NaN`, `+0`, `-0`  will no longer an issue.