### PR TITLE
feat(decorators): add decorators for view and resource config

### DIFF
--- a/dist/aurelia-templating.d.ts
+++ b/dist/aurelia-templating.d.ts
@@ -948,67 +948,12 @@ export declare class ShadowDOM {
   static distributeNodes(view?: any, nodes?: any, slots?: any, projectionSource?: any, index?: any, destinationOverride?: any): any;
 }
 
-export declare interface IStaticResourceConfig {
-  /**
-   * Resource type of this class, omit equals to custom element
-   */
-  type?: 'element' | 'attribute' | 'valueConverter' | 'bindingBehavior' | 'viewEngineHooks';
-  /**
-   * Name of this resource. Reccommended to explicitly set to works better with minifier
-   */
-  name?: string;
-  /**
-   * Used to tell if a custom attribute is a template controller
-   */
-  templateController?: boolean;
-  /**
-   * Used to set default binding mode of default custom attribute view model "value" property
-   */
-  defaultBindingMode?: bindingMode | keyof typeof bindingMode;
-  /**
-   * Flags a custom attribute has dynamic options
-   */
-  hasDynamicOptions?: boolean;
-  /**
-   * Flag if this custom element uses native shadow dom instead of emulation
-   */
-  usesShadowDOM?: boolean;
-  /**
-   * Options that will be used if the element is flagged with usesShadowDOM
-   */
-  shadowDOMOptions?: ShadowRootInit;
-  /**
-   * Flag a custom element as containerless. Which will remove their render target
-   */
-  containerless?: boolean;
-  /**
-   * Custom processing of the attributes on an element before the framework inspects them.
-   */
-  processAttributes?(viewCompiler: ViewCompiler, resources: ViewResources, node: Element, attributes: NamedNodeMap, elementInstruction: BehaviorInstruction): void;
-  /**
-   * Enables custom processing of the content that is places inside the custom element by its consumer.
-   * Pass a boolean to direct the template compiler to not process
-   * the content placed inside this element. Alternatively, pass a function which
-   * can provide custom processing of the content. This function should then return
-   * a boolean indicating whether the compiler should also process the content.
-   */
-  processContent?(viewCompiler: ViewCompiler, resources: ViewResources, node: Element, instruction: BehaviorInstruction): boolean;
-  /**
-   * List of bindable properties of this custom element / custom attribute, by name or full config object
-   */
-  bindables?: (string | IBindablePropertyConfig)[];
-}
-
-export declare class TargetResource extends Function {
-  static resource?: string | IStaticResourceConfig | { (): string | IStaticResourceConfig };
-}
-
 /**
 * Represents a collection of resources used during the compilation of a view.
 */
 export declare class ViewResources {
 
-  static convention(target: TargetResource): HtmlBehaviorResource | ValueConverterResource | BindingBehaviorResource | ViewEngineHooksResource | undefined;
+  static convention(target: Function): HtmlBehaviorResource | ValueConverterResource | BindingBehaviorResource | ViewEngineHooksResource | undefined;
 
   /**
     * A custom binding language used in the view.
@@ -1727,32 +1672,6 @@ export declare class BehaviorPropertyObserver {
     * @param callable The callable that was originally subscribed with.
     */
   unsubscribe(context: any, callable: Function): void;
-}
-
-export interface IBindablePropertyConfig {
-  /**
-  * The name of the property.
-  */
-  name?: string;
-  attribute?: string;
-  /**
-   * The default binding mode of the property. If given string, will use to lookup
-   */
-  defaultBindingMode?: bindingMode | keyof typeof bindingMode;
-  /**
-   * The name of a view model method to invoke when the property is updated.
-   */
-  changeHandler?: string;
-  /**
-   * A default value for the property.
-   */
-  defaultValue?: any;
-  /**
-   * Designates the property as the default bindable property among all the other bindable properties when used in a custom attribute with multiple bindable properties.
-   */
-  primaryProperty?: boolean;
-  // For compatibility and future extension
-  [key: string]: any;
 }
 
 /**

--- a/src/view-locator.js
+++ b/src/view-locator.js
@@ -1,5 +1,5 @@
 import {metadata, Origin} from 'aurelia-metadata';
-import {RelativeViewStrategy, ConventionalViewStrategy, StaticViewStrategy, viewStrategy} from './view-strategy';
+import {RelativeViewStrategy, ConventionalViewStrategy, StaticViewStrategy, viewStrategy, NoViewStrategy} from './view-strategy';
 
 /**
 * Locates a view for an object.
@@ -51,13 +51,15 @@ export class ViewLocator {
     }
 
     // static view strategy
-    if (value.view) {
-      let c = value.view;
-      c = typeof c === 'function' ? c() : c;
+    if ('$view' in value) {
+      let c = value.$view;
+      let view;
+      c = typeof c === 'function' ? c.call(value) : c;
       if (c === null) {
-        return new NoViewStrategy();
+        view = new NoViewStrategy();
+      } else {
+        view = c instanceof StaticViewStrategy ? c : new StaticViewStrategy(c);
       }
-      let view = c instanceof StaticViewStrategy ? c : new StaticViewStrategy(c);
       metadata.define(ViewLocator.viewStrategyMetadataKey, view, value);
       return view;
     }

--- a/test/decorators.spec.js
+++ b/test/decorators.spec.js
@@ -1,40 +1,80 @@
 ﻿import './setup';
-import {metadata} from 'aurelia-metadata';
-import {bindingMode} from 'aurelia-binding';
-import {customAttribute, customElement} from '../src/decorators';
+import { metadata } from 'aurelia-metadata';
+import { bindingMode } from 'aurelia-binding';
+import { customAttribute, customElement, resource, view } from '../src/decorators';
 
-describe('decorators', () => {
-    it('should leave resource attributeDefaultBindingMode as undefined when unspecified', () => {
-        var target = {};
+describe('@customAttribute', () => {
+  it('should leave resource attributeDefaultBindingMode as undefined when unspecified', () => {
+    var target = {};
 
-        var decorator = customAttribute('test');
-        decorator(target);
+    var decorator = customAttribute('test');
+    decorator(target);
 
-        var resource = metadata.get(metadata.resource, target);
-        expect(resource.attributeName).toBe('test');
-        expect(resource.attributeDefaultBindingMode).toBeUndefined();
-    });
+    var resource = metadata.get(metadata.resource, target);
+    expect(resource.attributeName).toBe('test');
+    expect(resource.attributeDefaultBindingMode).toBeUndefined();
+  });
 
-    it('should set resource attributeDefaultBindingMode when specified', () => {
-        var target = {};
+  it('should set resource attributeDefaultBindingMode when specified', () => {
+    var target = {};
 
-        var decorator = customAttribute('test', bindingMode.twoWay);
-        decorator(target);
+    var decorator = customAttribute('test', bindingMode.twoWay);
+    decorator(target);
 
-        var resource = metadata.get(metadata.resource, target);
-        expect(resource.attributeName).toBe('test');
-        expect(resource.attributeDefaultBindingMode).toBe(bindingMode.twoWay);
-    });
+    var resource = metadata.get(metadata.resource, target);
+    expect(resource.attributeName).toBe('test');
+    expect(resource.attributeDefaultBindingMode).toBe(bindingMode.twoWay);
+  });
 
-    it('should validate behavior names', () => {
-      expect(getBehaviorMetadata(customAttribute('fooBar')).attributeName).toBe('foo-bar');
-      expect(getBehaviorMetadata(customElement('fooBar')).elementName).toBe('foo-bar');
-      expect(getBehaviorMetadata(customAttribute('foo')).attributeName).toBe('foo');
-      expect(getBehaviorMetadata(customAttribute('foo-bar')).attributeName).toBe('foo-bar');
-    });
+  it('should validate behavior names', () => {
+    expect(getBehaviorMetadata(customAttribute('fooBar')).attributeName).toBe('foo-bar');
+    expect(getBehaviorMetadata(customElement('fooBar')).elementName).toBe('foo-bar');
+    expect(getBehaviorMetadata(customAttribute('foo')).attributeName).toBe('foo');
+    expect(getBehaviorMetadata(customAttribute('foo-bar')).attributeName).toBe('foo-bar');
+  });
 });
 
-function getBehaviorMetadata(decorator) {
+describe('@resources', () => {
+  it('should config when using a string', () => {
+    @resource('el')
+    class El {}
+    expect(El.$resource).toBe('el');
+  });
+
+  it('should config using a plain object', () => {
+    let config = {};
+    @resource(config)
+    class El {}
+    expect(El.$resource).toBe(config);
+  });
+
+  it('should define metadata using something else', () => {
+    let behaviorResource = new class FakeResource{}();
+    @resource(behaviorResource)
+    class El {}
+    expect(El.$resource).toBe(undefined);
+    expect(metadata.getOwn(metadata.resource, El)).toBe(behaviorResource);
+  });
+});
+
+describe('view strategy decorators', () => {
+  let baseTemplate = '<template></template>';
+  describe('@view', () => {
+    it('should creates static view field on target', () => {
+      @view(baseTemplate)
+      class El {}
+
+      expect(El.$view).toBe(baseTemplate);
+
+      class El2 {}
+      let config = {template: baseTemplate};
+      view(config)(El2);
+      expect(El2.$view).toBe(config);
+    });
+  })
+});
+
+function getBehaviorMetadata (decorator) {
   let target = {};
   decorator(target);
   return metadata.get(metadata.resource, target);

--- a/test/view-locator.spec.js
+++ b/test/view-locator.spec.js
@@ -1,13 +1,7 @@
-import './setup';
-import {metadata} from 'aurelia-metadata';
-import {bindingMode, valueConverter, bindingBehavior, ValueConverterResource, BindingBehaviorResource} from 'aurelia-binding';
-import {Container} from 'aurelia-dependency-injection';
-import { customElement, customAttribute } from '../src/decorators';
-import {ViewResources} from '../src/view-resources';
-import { HtmlBehaviorResource } from '../src/html-behavior';
-import { viewEngineHooks } from '../src/view-engine-hooks-resource';
+import { Container } from 'aurelia-dependency-injection';
 import { ViewLocator } from '../src/view-locator';
 import { StaticViewStrategy } from '../src/view-strategy';
+import './setup';
 
 describe('ViewLocator', () => {
   /**@type {Container} */
@@ -20,30 +14,30 @@ describe('ViewLocator', () => {
     viewLocator = new ViewLocator();
   });
 
-  describe('static view strategy', () => {
+  describe('static $view strategy', () => {
     it('works with static field and raw string', () => {
       class El {
-        static view = '<template></template>';
+        static $view = '<template></template>';
       }
       let strategy = viewLocator.getViewStrategy(El);
       expect(strategy instanceof StaticViewStrategy).toBe(true);
-      expect(strategy.template).toBe(El.view);
+      expect(strategy.template).toBe(El.$view);
     });
 
     it('works with static field', () => {
       class El {
-        static view = {
+        static $view = {
           template: '<template></template>'
         }
       }
       let strategy = viewLocator.getViewStrategy(El);
       expect(strategy instanceof StaticViewStrategy).toBe(true);
-      expect(strategy.template).toBe(El.view.template);
+      expect(strategy.template).toBe(El.$view.template);
     });
 
     it('works with static method', () => {
       class El {
-        static view() {
+        static $view() {
           return {
             template: '<template></template>'
           };
@@ -56,13 +50,33 @@ describe('ViewLocator', () => {
 
     it('works with static method and raw string', () => {
       class El {
-        static view() {
+        static $view() {
           return '<template></template>';
         }
       }
       let strategy = viewLocator.getViewStrategy(El);
       expect(strategy instanceof StaticViewStrategy).toBe(true);
       expect(strategy.template).toBe('<template></template>');
-    })
+    });
+
+    it('invokes static method with correct scope', () => {
+      class Base {
+        static template = '<template><div></div></template>';
+        static $view() {
+          return this.template;
+        }
+      }
+      class El extends Base{
+      }
+      let strategy = viewLocator.getViewStrategy(El);
+      expect(strategy instanceof StaticViewStrategy).toBe(true);
+      expect(strategy.template).toBe(Base.template);
+
+      class El1 extends Base {
+        static template = '<template>11</template>';
+      }
+      strategy = viewLocator.getViewStrategy(El1);
+      expect(strategy.template).toBe(El1.template);
+    });
   });
 });

--- a/test/view-strategy.spec.js
+++ b/test/view-strategy.spec.js
@@ -1,17 +1,11 @@
-import './setup';
-import { metadata } from 'aurelia-metadata';
-import { bindingMode, valueConverter, bindingBehavior, ValueConverterResource, BindingBehaviorResource } from 'aurelia-binding';
 import { Container } from 'aurelia-dependency-injection';
-import { customElement, customAttribute } from '../src/decorators';
-import { ViewResources } from '../src/view-resources';
-import { HtmlBehaviorResource } from '../src/html-behavior';
-import { viewEngineHooks } from '../src/view-engine-hooks-resource';
-import { ViewLocator } from '../src/view-locator';
-import { StaticViewStrategy } from '../src/view-strategy';
-import { ViewEngine } from '../src/view-engine';
-import { ViewCompiler } from '../src/view-compiler';
 import { BindingLanguage } from '../src/binding-language';
-import { ViewCompileInstruction, ResourceLoadContext } from '../src/instructions';
+import { ResourceLoadContext, ViewCompileInstruction } from '../src/instructions';
+import { ViewCompiler } from '../src/view-compiler';
+import { ViewEngine } from '../src/view-engine';
+import { ViewResources } from '../src/view-resources';
+import { StaticViewStrategy } from '../src/view-strategy';
+import './setup';
 
 describe('ViewLocator', () => {
   /**@type {ViewEngine} */
@@ -49,6 +43,8 @@ describe('ViewLocator', () => {
         .loadViewFactory(viewEngine, ViewCompileInstruction.normal, new ResourceLoadContext(), El)
         .then((factory) => {
           expect(factory.resources.getElement('el').target).toBe(El);
+        }).catch(ex => {
+          expect(ex.message).not.toContain('Cannot determine default view strategy for object.');
         }).then(done);
     });
   });
@@ -57,22 +53,22 @@ describe('ViewLocator', () => {
     class EmmaFrost {
     }
     class AquaMan {
-      static resource = {
+      static $resource = {
         type: 'attribute'
       }
     }
     class VentureCapital {
-      static resource = {
+      static $resource = {
         type: 'valueConverter'
       }
     }
     class BabyBoomer {
-      static resource = {
+      static $resource = {
         type: 'bindingBehavior'
       }
     }
     class BlitzCrank {
-      static resource = {
+      static $resource = {
         type: 'viewEngineHooks'
       }
 
@@ -91,28 +87,30 @@ describe('ViewLocator', () => {
         expect(resources.getValueConverter('ventureCapital') instanceof VentureCapital).toBe(true);
         expect(resources.getBindingBehavior('babyBoomer') instanceof BabyBoomer).toBe(true);
         expect(resources.beforeCompile).toBe(true);
+      }).catch(ex => {
+        expect(ex.message).not.toContain('Cannot determine default view strategy for object.');
       }).then(done);
   });
 
   it('loads async dependencies', done => {
     class Ekko {}
     class AureliaSol {
-      static resource = {
+      static $resource = {
         type: 'attribute'
       }
     }
     class Volibear {
-      static resource = {
+      static $resource = {
         type: 'valueConverter'
       }
     }
     class Braum {
-      static resource = {
+      static $resource = {
         type: 'bindingBehavior'
       }
     }
     class Thresh {
-      static resource = {
+      static $resource = {
         type: 'viewEngineHooks'
       }
       beforeCompile() {}
@@ -140,6 +138,9 @@ describe('ViewLocator', () => {
         expect(resources.getValueConverter('volibear') instanceof Volibear).toBe(true);
         expect(resources.getBindingBehavior('braum') instanceof Braum).toBe(true);
         expect(resources.beforeCompile).toBe(true);
+      })
+      .catch(ex => {
+        expect(ex.message).not.toContain('Cannot determine default view strategy for object.');
       }).then(done);
   });
 });


### PR DESCRIPTION
Follow up PR of #614 to have consistency with `@inject` and `static inject` 

I'm not certain about `@resource`, could be a breaking change but I don't think it's in use outside of templating-resources

@EisenbergEffect 