### PR TITLE
refactor(Slot): delay element injection

### DIFF
--- a/src/shadow-dom.js
+++ b/src/shadow-dom.js
@@ -4,8 +4,11 @@ import {_isAllWhitespace} from './util';
 
 let noNodes = Object.freeze([]);
 
-@inject(DOM.Element)
 export class SlotCustomAttribute {
+  static inject() {
+    return [DOM.Element];
+  }
+
   constructor(element) {
     this.element = element;
     this.element.auSlotAttribute = this;


### PR DESCRIPTION
With static resources / view registration, bootstrapping Aurelia can be done easier, and earlier. Change from immediately resolved `DOM.Element` to delayed injection. This also helps in some test scenarios where folks bootstrap and import this module at the same time, slot tests will fail.

@EisenbergEffect 