### PR TITLE
fix(view-compiler): Fix reference to next sibling node

### DIFF
--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -300,12 +300,13 @@ export class ViewCompiler {
     let knownAttribute;
     let auTargetID;
     let injectorId;
+    const nextSibling = node.nextSibling;
 
     if (tagName === 'slot') {
       if (targetLightDOM) {
         node = makeShadowSlot(this, resources, node, instructions, parentInjectorId);
       }
-      return node.nextSibling;
+      return nextSibling;
     } else if (tagName === 'template') {
       if (!('content' in node)) {
         throw new Error('You cannot place a template element within ' + node.namespaceURI + ' namespace');
@@ -453,7 +454,7 @@ export class ViewCompiler {
       }
 
       if (skipContentProcessing) {
-        return node.nextSibling;
+        return nextSibling;
       }
 
       let currentChild = node.firstChild;
@@ -462,7 +463,7 @@ export class ViewCompiler {
       }
     }
 
-    return node.nextSibling;
+    return nextSibling;
   }
 
   _configureProperties(instruction, resources) {


### PR DESCRIPTION
The _compileElement function returns the nextSibling of the compiled node. If you were to manipulate the element content however in such a way that the element was no longer a child of its original parent, the original next sibling would never be reached. This change keeps and uses a reference to the original next sibling element.

This change allows for modifying the parent structure of a custom element through the process callback function without prematurely quitting the compilation process.