### PR TITLE
fix(composition-engine): align class and moduleId behaviour

### DIFF
--- a/src/composition-engine.js
+++ b/src/composition-engine.js
@@ -169,8 +169,8 @@ export class CompositionEngine {
 
     if (typeof context.viewModel === 'string') {
       context.viewModel = context.viewResources
-          ? context.viewResources.relativeToView(context.viewModel)
-          : context.viewModel;
+        ? context.viewResources.relativeToView(context.viewModel)
+        : context.viewModel;
 
       return this.viewEngine.importViewModelResource(context.viewModel).then(viewModelResource => {
         childContainer.autoRegister(viewModelResource.value);
@@ -187,8 +187,12 @@ export class CompositionEngine {
     // When viewModel in context is not a module path
     // only prepare the metadata and ensure the view model instance is ready
     // if viewModel is a class, instantiate it
+    let ctor = context.viewModel.constructor;
     let isClass = typeof context.viewModel === 'function';
-    let ctor = isClass ? context.viewModel : context.viewModel.constructor;
+    if (isClass) {
+      ctor = context.viewModel;
+      childContainer.autoRegister(ctor);
+    }
     let m = metadata.getOrCreateOwn(metadata.resource, HtmlBehaviorResource, ctor);
     // We don't call ViewResources.prototype.convention here as it should be called later
     // Just need to prepare the metadata for later usage


### PR DESCRIPTION
I'm expecting regardless whether I use *moduleId* or *class* for `.viewModel` to get the same behaviour for instantiating the VM.
Currently if using a *class* and it has no registrations(@*transient*, etc.) or there is no resolver registered in the `.container`/`.childContainer`(from the `CompositionContext`) it will be instantiated and registered as singleton in the *root container*. In contrast when using *moduleId* the loaded *class* will be *auto registered* in the *child container*.
@bigopon is it intended?
