### PR TITLE
Fixed a memory leak where unbind was not called if view was already detached

### DIFF
--- a/src/view-slot.js
+++ b/src/view-slot.js
@@ -484,13 +484,11 @@ export class ViewSlot {
     let children = this.children;
     let ii = children.length;
 
-    if (this.isAttached) {
-      for (let i = 0; i < ii; ++i) {
-        if (returnToCache) {
-          children[i].returnToCache();
-        } else {
-          children[i].detached();
-        }
+    for (let i = 0; i < ii; ++i) {
+      if (returnToCache) {
+        children[i].returnToCache();
+      } else if (this.isAttached) {
+        children[i].detached();
       }
     }
 

--- a/test/view-slot.spec.js
+++ b/test/view-slot.spec.js
@@ -281,6 +281,16 @@ describe('view-slot', () => {
         viewSlot.remove(view, true);
         expect(view.returnToCache).toHaveBeenCalled();
       });
+
+      it('calls return to cache even when detached is true', () => {
+        spyOn(view, 'returnToCache');
+
+        viewSlot.add(view);
+        viewSlot.detached();
+        viewSlot.removeAll(true);
+
+        expect(view.returnToCache).toHaveBeenCalled();
+      });
     });
 
     describe('.removeAll', () => {


### PR DESCRIPTION
This is a fix related to [this issue](https://github.com/aurelia/templating/issues/541#issuecomment-416160922)

We noticed that some of our unbind's on components where not being called which caused a memory leak in our application. This pull request intends to fix this.

I'm not a 100% sure if this is the correct place to fix this issue and if it causes any different behaviour than intented. 