### PR TITLE
fix(view): skip view distribution on slot fallback fix #639

### DIFF
--- a/src/shadow-dom.js
+++ b/src/shadow-dom.js
@@ -40,6 +40,7 @@ export class PassThroughSlot {
   renderFallbackContent(view, nodes, projectionSource, index) {
     if (this.contentView === null) {
       this.contentView = this.fallbackFactory.create(this.ownerView.container);
+      this.contentView._isSlotFallback = true;
       this.contentView.bind(this.ownerView.bindingContext, this.ownerView.overrideContext);
 
       let slots = Object.create(null);
@@ -277,6 +278,7 @@ export class ShadowSlot {
   renderFallbackContent(view, nodes, projectionSource, index) {
     if (this.contentView === null) {
       this.contentView = this.fallbackFactory.create(this.ownerView.container);
+      this.contentView._isSlotFallback = true;
       this.contentView.bind(this.ownerView.bindingContext, this.ownerView.overrideContext);
       this.contentView.insertNodesBefore(this.anchor);
     }

--- a/src/view.js
+++ b/src/view.js
@@ -88,6 +88,7 @@ export class View {
     this.viewModelScope = null;
     this.animatableElement = undefined;
     this._isUserControlled = false;
+    this._isSlotFallback = false;
     this.contentView = null;
 
     for (let key in slots) {
@@ -166,7 +167,7 @@ export class View {
       children[i].bind(bindingContext, overrideContext, true);
     }
 
-    if (this.hasSlots) {
+    if (this.hasSlots && !this._isSlotFallback) {
       ShadowDOM.distributeView(this.contentView, this.slots);
     }
   }


### PR DESCRIPTION
`ShadowSlot` and `PassThroughSlot` have *custom* logic that calls [`ShadowDOM.distributeNodes`](https://github.com/aurelia/templating/blob/1.8.2/src/shadow-dom.js#L300)/[`ShadowDOM.distributeView`](https://github.com/aurelia/templating/blob/1.8.2/src/shadow-dom.js#L48) after binding the fallback `View`. Because of that `ShadowDOM.distributeView` should *not* be called in [`View.prototype.bind`](https://github.com/aurelia/templating/blob/1.8.2/src/view.js#L170) for fallback `View`s. Calling it results in the creation and binding of the *fallback* `View` for *tested* `<slots>`s *even* if override is provided for *that* nested `<slot>`. 
@EisenbergEffect @bigopon 