### PR TITLE
fix(StaticViewStrategy): set formal ".moduleId"

### DIFF
--- a/src/view-strategy.js
+++ b/src/view-strategy.js
@@ -280,6 +280,7 @@ export class StaticViewStrategy {
     this.dependencies = config.dependencies || [];
     this.factoryIsReady = false;
     this.onReady = null;
+    this.moduleId = 'undefined';
   }
 
   /**

--- a/test/view-strategy.spec.js
+++ b/test/view-strategy.spec.js
@@ -47,6 +47,11 @@ describe('ViewLocator', () => {
           expect(ex.message).not.toContain('Cannot determine default view strategy for object.');
         }).then(done);
     });
+
+    it('sets formal "moduleId"', () => {
+      const strategy = new StaticViewStrategy('<template><input value.bind="value" /></template>');
+      expect(strategy.moduleId).toBeDefined();
+    });
   });
 
   it('loads dependencies', (done) => {


### PR DESCRIPTION
Add *formal* `.moduleId` - `'undefined'`, so that one does *not* get [assigned](https://github.com/aurelia/templating/blob/1.8.2/src/html-behavior.js#L207) later on.
@bigopon 