### PR TITLE
fix(StaticViewStrategy): check for null template before compiling

### DIFF
--- a/src/view-strategy.js
+++ b/src/view-strategy.js
@@ -121,7 +121,7 @@ export class NoViewStrategy {
   * @param dependencies A list of view resource dependencies of this view.
   * @param dependencyBaseUrl The base url for the view dependencies.
   */
-  constructor(dependencies?: Array<string|Function|Object>, dependencyBaseUrl?: string) {
+  constructor(dependencies?: Array<string | Function | Object>, dependencyBaseUrl?: string) {
     this.dependencies = dependencies || null;
     this.dependencyBaseUrl = dependencyBaseUrl || '';
   }
@@ -213,7 +213,7 @@ export class InlineViewStrategy {
   * @param dependencies A list of view resource dependencies of this view.
   * @param dependencyBaseUrl The base url for the view dependencies.
   */
-  constructor(markup: string, dependencies?: Array<string|Function|Object>, dependencyBaseUrl?: string) {
+  constructor(markup: string, dependencies?: Array<string | Function | Object>, dependencyBaseUrl?: string) {
     this.markup = markup;
     this.dependencies = dependencies || null;
     this.dependencyBaseUrl = dependencyBaseUrl || '';
@@ -335,7 +335,9 @@ export class StaticViewStrategy {
       }
       // only load custom element as first step.
       return Promise.all(elDeps.map(el => el.load(container, el.target))).then(() => {
-        const factory = viewCompiler.compile(this.template, viewResources, compileInstruction);
+        const factory = this.template !== null
+          ? viewCompiler.compile(this.template, viewResources, compileInstruction)
+          : null;
         this.factoryIsReady = true;
         this.factory = factory;
         return factory;


### PR DESCRIPTION
When `.template` is `null` - `@view({template: null, dependencies: [SomeResource]})`, act as `NoViewStrategy` - process the dependencies and return `null` for factory.
`@view(null)` already works as `@noView`.