### PR TITLE
fix(Let): mark as target after creating instrutions

### DIFF
--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -320,13 +320,13 @@ export class ViewCompiler {
       // and the binding language has an implementation for it
       // This is an backward compat move
       if (tagName === 'let' && !type && bindingLanguage.createLetExpressions !== defaultLetHandler) {
-        auTargetID = makeIntoInstructionTarget(node);
         instructions[auTargetID] = TargetInstruction.letElement(
           bindingLanguage.createLetExpressions(
             resources,
             node
           )
         );
+        auTargetID = makeIntoInstructionTarget(node);
         return node.nextSibling;
       }
       if (type) {

--- a/test/view-compiler.spec.js
+++ b/test/view-compiler.spec.js
@@ -150,6 +150,28 @@ describe('ViewCompiler', () => {
         expect(viewCompiler.bindingLanguage.createLetExpressions).toHaveBeenCalled();
       });
 
+      it('marks as target instruction after creating expressions', () => {
+        const fragment = createFragment('<div><let>');
+        let instructions = { };
+        let count = 0;
+        viewCompiler.bindingLanguage.createLetExpressions = function(resources, letElement) {
+          count++;
+          expect(letElement.tagName).toBe('LET');
+          expect(letElement.classList.contains('au-target')).toBe(false, 'It should not have had .au-target');
+          expect(letElement.hasAttribute('au-target-id')).toBe(false, 'It should not have had [au-target-id]');
+          return {};
+        };
+        spyOn(viewCompiler.bindingLanguage, 'createLetExpressions').and.callThrough();
+        viewCompiler._compileNode(fragment, resources, instructions, null, 'root', true);
+        expect(Object.keys(instructions).length).toBe(1, 'It should have had 1 instruction');
+        expect(viewCompiler.bindingLanguage.createLetExpressions).toHaveBeenCalled();
+        const $letEl =fragment.querySelector('let');
+        expect(count).toBe(1, 'It should have had called the right fn');
+        expect($letEl).not.toBeNull();
+        expect($letEl.classList.contains('au-target')).toBe(true, 'It should have had .au-target');
+        expect($letEl.hasAttribute('au-target-id')).toBe(true, 'It should have had [au-target-id]');
+      });
+
       describe('backward compat', () => {
         it('does nothing if there is custom <let/> element', () => {
           let instructions = { };


### PR DESCRIPTION
On gitter:
> I'm seeing a few warning messages as a result of using the new let functionality. Not an issue - but is this pointing at a possible issue?
WARN Detected string literal in let bindings. Did you mean "auTargetId.bind=65" or "auTargetId=${65}" ?
from this code in a custom element.
<let interested.bind="important ? 'Important' : 'Interested'"></let>

Atm, `<let/>` gets transformed into an instruction target too early. Should delay until after binding language has finished creating the instructions. Thanks 
@EisenbergEffect 

Thanks to @MylesPenlington