### PR TITLE
fix(Let): properly create instruction Id

### DIFF
--- a/src/view-compiler.js
+++ b/src/view-compiler.js
@@ -320,13 +320,9 @@ export class ViewCompiler {
       // and the binding language has an implementation for it
       // This is an backward compat move
       if (tagName === 'let' && !type && bindingLanguage.createLetExpressions !== defaultLetHandler) {
-        instructions[auTargetID] = TargetInstruction.letElement(
-          bindingLanguage.createLetExpressions(
-            resources,
-            node
-          )
-        );
+        expressions = bindingLanguage.createLetExpressions(resources, node);
         auTargetID = makeIntoInstructionTarget(node);
+        instructions[auTargetID] = TargetInstruction.letElement(expressions);
         return node.nextSibling;
       }
       if (type) {

--- a/test/view-compiler.spec.js
+++ b/test/view-compiler.spec.js
@@ -184,6 +184,9 @@ describe('ViewCompiler', () => {
           expect(Object.keys(instructions).length).toBe(1, 'It should have had 1 instruction with let ce');
           let instruction;
           for (let id in instructions) {
+            // ensure instruction ids are valid
+            // there was a bug in compliation that caused id to be undefined
+            expect(parseInt(id, 10)).not.toBeNaN();
             instruction = instructions[id];
             break;
           }


### PR DESCRIPTION
Current behavior is having all calls in a single statement, this leads to a bug where instruction id cannot be properly created before creating instruction. Thanks to @graycrow for pointing this out.

cc @EisenbergEffect 