### PR TITLE
fix(static-view-strategy): correctly loads multiple custom elements in single file

### DIFF
--- a/src/view-strategy.js
+++ b/src/view-strategy.js
@@ -318,6 +318,9 @@ export class StaticViewStrategy {
         if (typeof dep === 'function') {
           // dependencies: [class1, class2, import('module').then(m => m.class3)]
           resource = viewResources.autoRegister(container, dep);
+          if (resource.elementName !== null) {
+            elDeps.push(resource);
+          }
         } else if (dep && typeof dep === 'object') {
           // dependencies: [import('module1'), import('module2')]
           for (let key in dep) {
@@ -325,12 +328,12 @@ export class StaticViewStrategy {
             if (typeof exported === 'function') {
               resource = viewResources.autoRegister(container, exported);
             }
+            if (resource.elementName !== null) {
+              elDeps.push(resource);
+            }
           }
         } else {
           throw new Error(`dependency neither function nor object. Received: "${typeof dep}"`);
-        }
-        if (resource.elementName !== null) {
-          elDeps.push(resource);
         }
       }
       // only load custom element as first step.


### PR DESCRIPTION
Atm, placing multiple custom elements, or custom elements as second export won't yield desirable outcome due to a bug in the way static view resolve a module exports. This PR fixes that issue.

@EisenbergEffect 