### PR TITLE
fix(static-view-strategy): correctly handles invalid resources

### DIFF
--- a/src/view-strategy.js
+++ b/src/view-strategy.js
@@ -327,9 +327,9 @@ export class StaticViewStrategy {
             let exported = dep[key];
             if (typeof exported === 'function') {
               resource = viewResources.autoRegister(container, exported);
-            }
-            if (resource.elementName !== null) {
-              elDeps.push(resource);
+              if (resource.elementName !== null) {
+                elDeps.push(resource);
+              }
             }
           }
         } else {


### PR DESCRIPTION
Atm, when one of the exports in module is not a function, it fails for the wrong reason as it tries to access `.elementName` of resource, which is undefined. This PR fixes that. Also add a test to cover invalid deps.