### PR TITLE
fix(karma): add retainLines to babelPreprocessor

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,6 +36,7 @@ module.exports = function(config) {
     'babelPreprocessor': {
       options: {
         sourceMap: 'inline',
+        retainLines: true,
         presets: [ 'es2015-loose', 'stage-1'],
         plugins: [
           'syntax-flow',


### PR DESCRIPTION
When a test fails under Karma the console stacktrace contains incorrect line
numbers making debugging impossible.

Applying fix manually as described in https://github.com/chriscasola/karma/commit/67d1cfe5bc4a85c039bb4d8af36b366879aa6cc0

closes aurelia/templating#670