### PR TITLE
Fix inline views when template uses unescaped variables

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -36,6 +36,7 @@ module.exports = function(config) {
     'babelPreprocessor': {
       options: {
         sourceMap: 'inline',
+        retainLines: true,
         presets: [ 'es2015-loose', 'stage-1'],
         plugins: [
           'syntax-flow',


### PR DESCRIPTION
I'm trying to see if its possible to write a test for the case where the template literal variable is unescaped.

The decorator should get the exception and be able to provide a warning message that the input might have unescaped dollar signs in template literals.

However the current `view-strategy.spec.js` hacks together a `ViewEngine` like object. That was simple enough to replace and the tests still work.

You can see from my attempt to create a test for `InlineViewStrategy` that the `.getElement(el)` call returns null. 

I probably should be testing closer to the decorator usage and missing some magic setup that my lack of familiarity is causing.

Is this something else to debug and fix?