### PR TITLE
chore(dep): fix vuln issues with latest framework pkg

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@typescript-eslint/eslint-plugin": "^5.17.0",
         "@typescript-eslint/parser": "^5.17.0",
         "aurelia-bootstrapper": "^2.3.3",
-        "aurelia-framework": "^1.3.1",
+        "aurelia-framework": "^1.4.0",
         "aurelia-history": "^1.2.1",
         "aurelia-history-browser": "^1.4.0",
         "aurelia-loader-webpack": "^2.2.1",
@@ -920,9 +920,9 @@
       }
     },
     "node_modules/aurelia-framework": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/aurelia-framework/-/aurelia-framework-1.3.1.tgz",
-      "integrity": "sha512-eKR+JnrVzYQ372pokHjfw+YfiGpFIO6yGOotGHkeLtIVZcVowX4oYe1HEkDe7/VXU3f6cDILoYkNIwrZUBij0g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/aurelia-framework/-/aurelia-framework-1.4.0.tgz",
+      "integrity": "sha512-7Mov9G/LTqH8VZ/D44LrrgbrlOv4xzgUbZS+MCt6XErD+JeXqDIDC4XZvn4YZAUj6ACpSfUVgP9bF/195wV+Qg==",
       "dev": true,
       "dependencies": {
         "aurelia-binding": "^2.0.0",
@@ -931,9 +931,9 @@
         "aurelia-logging": "^1.0.0",
         "aurelia-metadata": "^1.0.0",
         "aurelia-pal": "^1.0.0",
-        "aurelia-path": "^1.0.0",
+        "aurelia-path": "^1.1.7",
         "aurelia-task-queue": "^1.0.0",
-        "aurelia-templating": "^1.8.1"
+        "aurelia-templating": "^1.11.0"
       }
     },
     "node_modules/aurelia-history": {
@@ -1080,9 +1080,9 @@
       }
     },
     "node_modules/aurelia-templating": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/aurelia-templating/-/aurelia-templating-1.10.4.tgz",
-      "integrity": "sha512-w1AtGneeRRJJPxr7QiGwTyLOsspPSF0xg1bKJnMntVhGC265SrtEAIsF1aKXOuLVTrjhx1Vi+3xPiJ560ilwtw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aurelia-templating/-/aurelia-templating-1.11.0.tgz",
+      "integrity": "sha512-c3IxNtCDUSfLE7jQg77P21Vrwbvj2zLGt/x8Zu96dmThAmCZGdWNj4sJCOcfWy3gDPyiWDDcJOolDyYcMmbBXg==",
       "dev": true,
       "dependencies": {
         "aurelia-binding": "^2.0.0",
@@ -1091,7 +1091,7 @@
         "aurelia-logging": "^1.0.0",
         "aurelia-metadata": "^1.0.0",
         "aurelia-pal": "^1.0.0",
-        "aurelia-path": "^1.0.0",
+        "aurelia-path": "^1.1.7",
         "aurelia-task-queue": "^1.1.0"
       }
     },
@@ -6249,9 +6249,9 @@
       }
     },
     "aurelia-framework": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/aurelia-framework/-/aurelia-framework-1.3.1.tgz",
-      "integrity": "sha512-eKR+JnrVzYQ372pokHjfw+YfiGpFIO6yGOotGHkeLtIVZcVowX4oYe1HEkDe7/VXU3f6cDILoYkNIwrZUBij0g==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/aurelia-framework/-/aurelia-framework-1.4.0.tgz",
+      "integrity": "sha512-7Mov9G/LTqH8VZ/D44LrrgbrlOv4xzgUbZS+MCt6XErD+JeXqDIDC4XZvn4YZAUj6ACpSfUVgP9bF/195wV+Qg==",
       "dev": true,
       "requires": {
         "aurelia-binding": "^2.0.0",
@@ -6260,9 +6260,9 @@
         "aurelia-logging": "^1.0.0",
         "aurelia-metadata": "^1.0.0",
         "aurelia-pal": "^1.0.0",
-        "aurelia-path": "^1.0.0",
+        "aurelia-path": "^1.1.7",
         "aurelia-task-queue": "^1.0.0",
-        "aurelia-templating": "^1.8.1"
+        "aurelia-templating": "^1.11.0"
       }
     },
     "aurelia-history": {
@@ -6399,9 +6399,9 @@
       }
     },
     "aurelia-templating": {
-      "version": "1.10.4",
-      "resolved": "https://registry.npmjs.org/aurelia-templating/-/aurelia-templating-1.10.4.tgz",
-      "integrity": "sha512-w1AtGneeRRJJPxr7QiGwTyLOsspPSF0xg1bKJnMntVhGC265SrtEAIsF1aKXOuLVTrjhx1Vi+3xPiJ560ilwtw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/aurelia-templating/-/aurelia-templating-1.11.0.tgz",
+      "integrity": "sha512-c3IxNtCDUSfLE7jQg77P21Vrwbvj2zLGt/x8Zu96dmThAmCZGdWNj4sJCOcfWy3gDPyiWDDcJOolDyYcMmbBXg==",
       "dev": true,
       "requires": {
         "aurelia-binding": "^2.0.0",
@@ -6410,7 +6410,7 @@
         "aurelia-logging": "^1.0.0",
         "aurelia-metadata": "^1.0.0",
         "aurelia-pal": "^1.0.0",
-        "aurelia-path": "^1.0.0",
+        "aurelia-path": "^1.1.7",
         "aurelia-task-queue": "^1.1.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@typescript-eslint/eslint-plugin": "^5.17.0",
     "@typescript-eslint/parser": "^5.17.0",
     "aurelia-bootstrapper": "^2.3.3",
-    "aurelia-framework": "^1.3.1",
+    "aurelia-framework": "^1.4.0",
     "aurelia-history": "^1.2.1",
     "aurelia-history-browser": "^1.4.0",
     "aurelia-loader-webpack": "^2.2.1",

--- a/src/view-resources.ts
+++ b/src/view-resources.ts
@@ -572,7 +572,6 @@ export class ViewResources {
   }
 
   /**
-   * @internal
    * Not supported for public use. Can be changed without warning.
    *
    * Auto register a resources based on its metadata or convention


### PR DESCRIPTION
This upgrade the minimum requirement for `aurelia-framework` dev dependency to `1.4.0`, allowing the vulv issue reported at https://github.com/aurelia/framework/issues/992 to be resolved.